### PR TITLE
Add persistent staging URL for devel deploys

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,7 +60,12 @@ jobs:
         if: github.ref == 'refs/heads/devel'
         working-directory: uncivilised-game-base
         run: |
-          vercel deploy \
+          DEPLOY_URL=$(vercel deploy \
             --token=${{ secrets.VERCEL_TOKEN }} \
-            --yes
+            --yes)
+          echo "Preview URL: $DEPLOY_URL"
+          vercel alias "$DEPLOY_URL" staging.uncivilized.fun \
+            --token=${{ secrets.VERCEL_TOKEN }}
           echo "### Staging deployed" >> $GITHUB_STEP_SUMMARY
+          echo "Live at: https://staging.uncivilized.fun" >> $GITHUB_STEP_SUMMARY
+          echo "Preview: $DEPLOY_URL" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

- Captures the Vercel deploy URL from `devel` branch deploys and aliases it to `staging.uncivilized.fun`
- Provides a stable, persistent staging URL that always points to the latest `devel` build
- Adds the staging and preview URLs to the GitHub Actions job summary

## Manual step required

Before merging, `staging.uncivilized.fun` needs to be added as a domain in the Vercel project settings (and DNS configured with a CNAME pointing to `cname.vercel-dns.com`).

## Test plan

- [ ] Add `staging.uncivilized.fun` as a domain in Vercel project settings
- [ ] Configure DNS CNAME record for `staging.uncivilized.fun` → `cname.vercel-dns.com`
- [ ] Merge to `devel` and verify the deploy workflow succeeds
- [ ] Confirm `https://staging.uncivilized.fun` resolves to the latest devel build

https://claude.ai/code/session_017hdj6gjoeckTcmXGS2wLwZ