### PR TITLE
Fix canvas transform accumulation causing fractal map / black screen

### DIFF
--- a/src/discovery.js
+++ b/src/discovery.js
@@ -65,6 +65,10 @@ function discoverVisibleFactions() {
   }
 }
 
+// Queue of pending first-contact greetings — processed one at a time
+const _greetingQueue = [];
+let _greetingInProgress = false;
+
 function discoverFaction(factionId, method) {
   if (!game.metFactions) game.metFactions = {};
   if (game.metFactions[factionId]) return;
@@ -83,8 +87,27 @@ function discoverFaction(factionId, method) {
   }
   // Queue auto-greeting (runs after current turn processing completes)
   if (method !== 'introduction') {
+    _greetingQueue.push({ factionId, method });
     // Small delay so the turn processing finishes before opening the chat
-    setTimeout(() => triggerFirstContactGreeting(factionId, method), 600);
+    if (!_greetingInProgress) {
+      setTimeout(processGreetingQueue, 600);
+    }
+  }
+}
+
+async function processGreetingQueue() {
+  if (_greetingInProgress || _greetingQueue.length === 0) return;
+  _greetingInProgress = true;
+  const { factionId, method } = _greetingQueue.shift();
+  try {
+    await triggerFirstContactGreeting(factionId, method);
+  } catch (err) {
+    console.error('First contact greeting error:', err);
+  }
+  _greetingInProgress = false;
+  // Process next queued greeting after a short delay
+  if (_greetingQueue.length > 0) {
+    setTimeout(processGreetingQueue, 800);
   }
 }
 

--- a/src/render.js
+++ b/src/render.js
@@ -1,5 +1,5 @@
 import { HEX_SIZE, SQRT3, MAP_COLS, MAP_ROWS, BASE_TERRAIN, TERRAIN_FEATURES, RESOURCES, UNIT_TYPES, FACTIONS, NATURAL_WONDERS, TILE_IMPROVEMENTS, UNIT_SPRITE_MAP, ZOOM_MIN, ZOOM_MAX, CITY_DEFENSE, BARBARIAN_UNITS, BUILDINGS, WONDERS } from './constants.js';
-import { game, canvas, ctx, miniCanvas, miniCtx, canvasW, canvasH, setCanvasSize, gameZoom, hoveredHex, LOCKED_DPR, tilesLoaded, TERRAIN_TILE_IMAGES, IMPROVEMENT_IMAGES, unitAtlas, animRunning } from './state.js';
+import { game, canvas, ctx, miniCanvas, miniCtx, canvasW, canvasH, setCanvasSize, gameZoom, setGameZoom, hoveredHex, LOCKED_DPR, tilesLoaded, TERRAIN_TILE_IMAGES, IMPROVEMENT_IMAGES, unitAtlas, animRunning } from './state.js';
 import { hexToPixel, pixelToHex, drawHex, getHexNeighbors, hexDistance } from './hex.js';
 import { valueNoise, fbmNoise, rgbStr, adjustBrightness, hexToRgba, getTerrainTileImage } from './utils.js';
 import { drawDetailedHex } from './terrain-render.js';
@@ -112,6 +112,9 @@ function computeVisibility() {
 
 function render() {
   if (!game) return;
+  // Reset transform unconditionally — prevents accumulated scale from corrupted
+  // frames where ctx.restore() was skipped due to an exception.
+  ctx.setTransform(LOCKED_DPR, 0, 0, LOCKED_DPR, 0, 0);
   // Sanitize camera state — prevent NaN/Infinity from corrupting the frame
   if (!isFinite(game.cameraX)) game.cameraX = 0;
   if (!isFinite(game.cameraY)) game.cameraY = 0;
@@ -122,8 +125,14 @@ function render() {
   ctx.fillStyle = '#0a0c0b';
   ctx.fillRect(0, 0, canvasW, canvasH);
 
-  // Apply zoom
+  // Sanitize zoom — clamp to valid range to prevent runaway scaling
+  if (!isFinite(gameZoom) || gameZoom < ZOOM_MIN || gameZoom > ZOOM_MAX) {
+    setGameZoom(1.0);
+  }
+
+  // Apply zoom — wrapped in try/finally to guarantee restore() runs
   ctx.save();
+  try {
   ctx.scale(gameZoom, gameZoom);
   ctx.imageSmoothingEnabled = true;
   ctx.imageSmoothingQuality = 'high';
@@ -283,6 +292,7 @@ function render() {
 
       // Faction territory with borders
       for (const [fid, fc] of Object.entries(game.factionCities)) {
+        if (!fc.color) continue;
         const dist = hexDistance(c, r, fc.col, fc.row);
         if (dist <= 2) {
           drawHex(ctx, sx, sy, HEX_SIZE - 1);
@@ -889,7 +899,9 @@ function render() {
     ctx.stroke();
   }
 
-  ctx.restore(); // End zoom transform
+  } finally {
+    ctx.restore(); // End zoom transform
+  }
   renderMiniMap();
 }
 


### PR DESCRIPTION
## Summary

- **Root cause:** `render()` uses `ctx.save()` + `ctx.scale(gameZoom)` and `ctx.restore()` but any uncaught exception between them leaves the save stack unbalanced — subsequent renders compound the zoom (`gameZoom²`, `gameZoom³`...), producing the fractal/recursive map copies shrinking toward top-left
- **render.js:** Reset canvas transform at frame start (`setTransform`), wrap render body in `try/finally` to guarantee `restore()`, sanitize zoom value, add null guard on `fc.color` in faction territory rendering
- **discovery.js:** Queue first-contact greetings so multiple simultaneous faction discoveries don't fire concurrent greeting flows that race with each other

## Test plan

- [ ] Play through ~30 turns with zoom/scroll — no fractal copies or black screen
- [ ] Encounter a faction — chat opens cleanly, map doesn't corrupt
- [ ] Discover multiple factions in quick succession (e.g. via scout revealing a large area) — greetings queue properly
- [ ] End turn transitions don't cause black screen
- [ ] Trackpad pinch zoom still works correctly

## Linked issues (do not auto-close — QA on staging first)

Addresses #58, #66, #70
Related: #61, #73