### PR TITLE
Fix tribal village: transparent PNG, hex clip, 50% smaller

### DIFF
--- a/src/render.js
+++ b/src/render.js
@@ -246,7 +246,7 @@ function render() {
             }
             ctx.closePath();
             ctx.clip();
-            const imgS = HEX_SIZE * 2.0;
+            const imgS = HEX_SIZE * 1.0;
             ctx.drawImage(villageImg, sx - imgS / 2, sy - imgS / 2, imgS, imgS);
             ctx.restore();
           }


### PR DESCRIPTION
## Summary

- Replaced tribal_village.jpg with transparent PNG (100KB, 256x256)
- Added hex clipping path so village fits within hex tile shape
- Reduced village sprite from `HEX_SIZE * 2.0` to `HEX_SIZE * 1.0` (50% smaller to match other building sizes)
- Fixed broken `unitMoveAnim`/`setUnitMoveAnim` imports that were breaking the build on devel

https://claude.ai/code/session_01HHrezJE655nSmV2fFgubYd