### PR TITLE
Fix: units unable to move (unitMoveAnim ReferenceError)

### DIFF
--- a/src/units.js
+++ b/src/units.js
@@ -572,7 +572,7 @@ function handleHexClick(col, row) {
   if (col < 0 || col >= MAP_COLS || row < 0 || row >= MAP_ROWS) return;
   if (!game.fogOfWar[row][col]) return;
   // Block clicks while unit movement animation is in progress
-  if (unitMoveAnim) return;
+  if (game._unitMoveAnim) return;
 
   // If a player unit is selected
   if (game.selectedUnitId) {


### PR DESCRIPTION
## Summary

`handleHexClick` referenced the removed `unitMoveAnim` variable (line 575), causing a `ReferenceError` that killed all click handling — units could not move at all.

Changed `if (unitMoveAnim) return;` to `if (game._unitMoveAnim) return;` to match the other fixed references.

## Root cause

PR #117 fixed the `import` line and `setUnitMoveAnim` calls but missed this one read reference inside `handleHexClick`.

https://claude.ai/code/session_01HHrezJE655nSmV2fFgubYd