### PR TITLE
Fix QA audit bugs: undefined needsPop, inconsistent tooltips, dead code

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -140,8 +140,3 @@ export function setActiveGameRecord(v) { activeGameRecord = v; }
 
 export let animRunning = false;
 export function setAnimRunning(v) { animRunning = v; }
-
-// Unit move animation — when non-null an animation is in progress
-// { unitId, path: [{col,row}...], step, onComplete }
-export let unitMoveAnim = null;
-export function setUnitMoveAnim(v) { unitMoveAnim = v; }

--- a/src/ui-panels.js
+++ b/src/ui-panels.js
@@ -476,8 +476,9 @@ function renderUnitsPanel() {
     const requiredTech = UNIT_UNLOCKS[typeId];
     const techUnlocked = !requiredTech || game.techs.includes(requiredTech);
     const needsBarracks = !['scout', 'warrior', 'slinger', 'worker', 'settler'].includes(typeId);
+    const needsPop = typeId === 'settler' && game.population < 2000;
     const canRecruit = techUnlocked && (!needsBarracks || hasBarracks) && !needsPop;
-    const reason = !techUnlocked ? `Needs ${requiredTech}` : (needsBarracks && !hasBarracks) ? 'Needs Barracks' : needsPop ? 'Need pop 2,000+' : '';
+    const reason = !techUnlocked ? `Requires ${getTechNameById(requiredTech)}` : (needsBarracks && !hasBarracks) ? 'Requires Barracks' : needsPop ? 'Requires population 2,000+' : '';
 
     const div = document.createElement('div');
     div.className = `build-item ${!canRecruit ? 'item-disabled' : ''}`;


### PR DESCRIPTION
## Summary

Fixes found during code-level QA audit:

- **Bug**: `needsPop` undefined in legacy unit recruit panel (renderUnitsPanel) — settler could be recruited without meeting population requirement
- **Bug**: Tech names shown as raw IDs ("Needs bronze_working") instead of display names ("Requires Bronze Working") in legacy panel
- **Cleanup**: Removed dead `unitMoveAnim`/`setUnitMoveAnim` exports from state.js

https://claude.ai/code/session_01HHrezJE655nSmV2fFgubYd