### PR TITLE
Reduce redrawing of the canvas to 30 fps.

### DIFF
--- a/src/render.js
+++ b/src/render.js
@@ -905,7 +905,8 @@ function render() {
   }
 
   // Draw units
-  const pulseT = (Date.now() % 1500) / 1500;
+  const pulseFrameRate = 30;
+  const pulseT = floor(((Date.now() % 1500) / 1500) * pulseFrameRate) / pulseFrameRate;
   const pulseAlpha = 0.4 + 0.6 * Math.abs(Math.sin(pulseT * Math.PI));
   const pulseRadius = 13 + 3 * Math.abs(Math.sin(pulseT * Math.PI));
 


### PR DESCRIPTION
Reduce redrawing of the canvas to 30 times per second when a unit is selected to stop my computer from melting.

I have no idea if this will work as I cannot run the game locally, but at the moment whenever a unit is pulsing, my laptop fans start whirring hard. I guess it is rendering the canvas as often as possible (hundreds of FPS?)