### PR TITLE
Fix frozen units by resetting movement before AI processing

### DIFF
--- a/src/turn.js
+++ b/src/turn.js
@@ -156,6 +156,7 @@ function endTurn() {
   for (const unit of game.units) {
     if (unit.owner !== 'player') continue;
     const ut = UNIT_TYPES[unit.type];
+    const didIdleLastTurn = unit.moveLeft === ut.movePoints;
     unit.moveLeft = ut.movePoints;
     unit.hasAttackedThisTurn = false;
 
@@ -174,7 +175,7 @@ function endTurn() {
       } else if (unit.fortified) {
         // Fortified: +10 HP
         healAmount = 10;
-      } else if (unit.moveLeft === ut.movePoints) {
+      } else if (didIdleLastTurn) {
         // Didn't move last turn (full moves remaining means they were idle): +5 HP
         healAmount = 5;
       }


### PR DESCRIPTION
## Summary
- Player movement reset was running AFTER `processAITurns()` — any exception during AI processing (from `game.units` array mutation in combat/city strikes) got caught by the outer try/catch, silently skipping movement reset. All player units stuck at 0 movement permanently.
- Moved player movement/healing/waypoint reset to run BEFORE AI processing
- Wrapped each AI processing step (`processAITurns`, `processZOCCaptures`, `processAIWonderTurns`, diplomacy) in individual try/catch blocks so failures are isolated

## Root cause
`processAITurns()` in the diplomacy plugin iterates `game.units` with `for...of` while `resolveCombat()` and city ranged strikes reassign `game.units = game.units.filter(...)`, which can cause undefined property access on stale unit references, throwing an exception that the outer try/catch swallows — blocking everything after it including movement reset.

Closes #138, closes #150, closes #140

## Test plan
- [ ] Start a new game, play through 20+ turns — verify units get movement each turn
- [ ] Set waypoints on units, end turn — verify waypoint movement works
- [ ] Get into combat with AI factions — verify units aren't frozen after AI attacks
- [ ] Verify end turn button remains functional throughout