### PR TITLE
feat: add per-unit-class terrain movement modifiers

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -68,6 +68,25 @@ export let UNIT_TYPES = {
 };
 
 // ============================================
+// UNIT CLASS TERRAIN MODIFIERS
+// ============================================
+// Per-class multipliers applied to terrain movement costs.
+// < 1 = faster through that terrain, > 1 = slower, 0 = ignore terrain penalty entirely.
+// 'flat' applies to base cost-1 tiles (grassland, plains, desert, etc.).
+// 'rough' applies to features with cost >= 2 (hills, woods, marsh, rainforest).
+// 'road' applies when moving on roads.
+export const UNIT_CLASS_TERRAIN_MODS = {
+  recon:    { flat: 1, rough: 1, road: 1, ignoreRoughPenalty: true },  // Scouts ignore rough terrain "all moves" penalty
+  melee:    { flat: 1, rough: 1, road: 1, ignoreRoughPenalty: false },
+  ranged:   { flat: 1, rough: 1, road: 1, ignoreRoughPenalty: false },
+  'anti-cav': { flat: 1, rough: 1, road: 1, ignoreRoughPenalty: false },
+  cavalry:  { flat: 1, rough: 1.5, road: 1, ignoreRoughPenalty: false }, // Cavalry slower in rough terrain
+  civilian: { flat: 1, rough: 1, road: 0.5, ignoreRoughPenalty: false }, // Workers/settlers faster on roads
+  siege:    { flat: 1, rough: 1.5, road: 1, ignoreRoughPenalty: false }, // Siege slow in rough terrain
+  naval:    { flat: 99, rough: 99, road: 99, ignoreRoughPenalty: false }, // Naval can't go on land
+};
+
+// ============================================
 // ZONE OF CONTROL — civilian units don't project ZOC (but are still affected by it)
 // ============================================
 export const ZOC_EXEMPT_CLASSES = ['civilian'];

--- a/src/map.js
+++ b/src/map.js
@@ -1,4 +1,4 @@
-import { MAP_COLS, MAP_ROWS, BASE_TERRAIN, TERRAIN_FEATURES, RESOURCES, TECHNOLOGIES, NATURAL_WONDERS, FACTIONS, FACTION_TRAITS, GOVERNMENTS, WONDERS } from './constants.js';
+import { MAP_COLS, MAP_ROWS, BASE_TERRAIN, TERRAIN_FEATURES, RESOURCES, TECHNOLOGIES, NATURAL_WONDERS, FACTIONS, FACTION_TRAITS, GOVERNMENTS, WONDERS, UNIT_CLASS_TERRAIN_MODS } from './constants.js';
 import { game } from './state.js';
 import { hexDistance, getHexNeighbors } from './hex.js';
 import { simplex } from './utils.js';
@@ -712,13 +712,21 @@ function getTileYields(tile) {
   return { food, prod, gold };
 }
 
-function getTileMoveCost(tile) {
-  // Roads halve movement cost (min 0.5)
+function getTileMoveCost(tile, unitClass) {
+  const mods = unitClass ? UNIT_CLASS_TERRAIN_MODS[unitClass] : null;
+  // Roads halve movement cost (min 0.5), further modified by unit class
   if (tile.road) {
     const baseCost = getTileBaseMoveCost(tile);
-    return Math.max(0.5, baseCost * 0.5);
+    let roadCost = Math.max(0.5, baseCost * 0.5);
+    if (mods && mods.road !== 1) roadCost = Math.max(0.5, roadCost * mods.road);
+    return roadCost;
   }
-  return getTileBaseMoveCost(tile);
+  const base = getTileBaseMoveCost(tile);
+  if (base >= 99 || !mods) return base;
+  // Apply rough/flat modifier
+  const isRough = base >= 2;
+  const mod = isRough ? mods.rough : mods.flat;
+  return Math.max(1, Math.round(base * mod * 10) / 10);
 }
 
 function getTileBaseMoveCost(tile) {

--- a/src/units.js
+++ b/src/units.js
@@ -1,4 +1,4 @@
-import { MAP_COLS, MAP_ROWS, BASE_TERRAIN, UNIT_TYPES, UNIT_UPGRADES, UNIT_UNLOCKS, UNIT_PROMOTIONS, FACTIONS, FACTION_TRAITS, TILE_IMPROVEMENTS, ZOC_EXEMPT_CLASSES } from './constants.js';
+import { MAP_COLS, MAP_ROWS, BASE_TERRAIN, UNIT_TYPES, UNIT_UPGRADES, UNIT_UNLOCKS, UNIT_PROMOTIONS, FACTIONS, FACTION_TRAITS, TILE_IMPROVEMENTS, ZOC_EXEMPT_CLASSES, UNIT_CLASS_TERRAIN_MODS } from './constants.js';
 import { game, getNextUnitId } from './state.js';
 import { hexToPixel, pixelToHex, getHexNeighbors, hexDistance } from './hex.js';
 import { getTileMoveCost, isTilePassable, crossesRiver, roadBridgesRiver } from './map.js';
@@ -167,6 +167,9 @@ function computeMoveRange() {
 
   // ZOC: check if unit starts in enemy ZOC
   const unitStartsInZOC = isInEnemyZOC(unit.col, unit.row, unit.owner);
+  const ut = UNIT_TYPES[unit.type];
+  const unitClass = ut ? ut.class : null;
+  const classMods = unitClass ? UNIT_CLASS_TERRAIN_MODS[unitClass] : null;
 
   while (queue.length > 0) {
     const cur = queue.shift();
@@ -174,18 +177,20 @@ function computeMoveRange() {
     const neighbors = getHexNeighbors(cur.col, cur.row);
     for (const nb of neighbors) {
       const tile = game.map[nb.row][nb.col];
-      const cost = getTileMoveCost(tile);
+      const cost = getTileMoveCost(tile, unitClass);
       if (cost >= 99) continue;
       // Civ-style movement rules:
       // - Flat terrain (cost 1): deduct 1 MP, keep moving
       // - Rough terrain (cost 2+: hills, woods, marsh, rainforest):
       //   uses ALL remaining movement points (can always enter with 1+ MP)
+      //   UNLESS the unit class has ignoreRoughPenalty (e.g. scouts)
       // - Roads halve cost (0.5), always allow continued movement
       // - River crossing: uses ALL remaining MP (unless road bridge on both sides)
       const isRiverCross = crossesRiver(cur.col, cur.row, nb.col, nb.row)
                         && !roadBridgesRiver(cur.col, cur.row, nb.col, nb.row);
       const isRoughTerrain = cost >= 2;
-      let remaining = (isRoughTerrain || isRiverCross) ? 0 : (cur.move - cost);
+      const ignoreRough = classMods && classMods.ignoreRoughPenalty;
+      let remaining = (isRiverCross || (isRoughTerrain && !ignoreRough)) ? 0 : (cur.move - cost);
 
       // Zone of Control: entering an enemy ZOC hex ends movement
       const nbInZOC = isInEnemyZOC(nb.col, nb.row, unit.owner);
@@ -199,7 +204,6 @@ function computeMoveRange() {
       const blockingUnit = game.units.find(u => u.col === nb.col && u.row === nb.row && u.id !== unit.id);
       if (blockingUnit) continue;
       // Civilian units can't enter enemy city tiles
-      const ut = UNIT_TYPES[unit.type];
       if (ut && ut.class === 'civilian') {
         const isEnemyCity = Object.entries(game.factionCities).some(([, fc]) => fc.col === nb.col && fc.row === nb.row)
           || (game.aiFactionCities && Object.values(game.aiFactionCities).some(cities =>
@@ -230,6 +234,9 @@ function computeRiverCrossings() {
   const visited = new Map();
   const queue = [{ col: unit.col, row: unit.row, move: unit.moveLeft, crossedRiver: false }];
   visited.set(`${unit.col},${unit.row}`, unit.moveLeft);
+  const rut = UNIT_TYPES[unit.type];
+  const rUnitClass = rut ? rut.class : null;
+  const rClassMods = rUnitClass ? UNIT_CLASS_TERRAIN_MODS[rUnitClass] : null;
 
   while (queue.length > 0) {
     const cur = queue.shift();
@@ -237,12 +244,13 @@ function computeRiverCrossings() {
     const neighbors = getHexNeighbors(cur.col, cur.row);
     for (const nb of neighbors) {
       const tile = game.map[nb.row][nb.col];
-      const cost = getTileMoveCost(tile);
+      const cost = getTileMoveCost(tile, rUnitClass);
       if (cost >= 99) continue;
       const isRiverCross = crossesRiver(cur.col, cur.row, nb.col, nb.row)
                         && !roadBridgesRiver(cur.col, cur.row, nb.col, nb.row);
       const isRoughTerrain = cost >= 2;
-      const remaining = (isRoughTerrain || isRiverCross) ? 0 : (cur.move - cost);
+      const rIgnoreRough = rClassMods && rClassMods.ignoreRoughPenalty;
+      const remaining = (isRiverCross || (isRoughTerrain && !rIgnoreRough)) ? 0 : (cur.move - cost);
       const key = `${nb.col},${nb.row}`;
       if (visited.has(key) && visited.get(key) >= remaining) continue;
       const blockingUnit = game.units.find(u => u.col === nb.col && u.row === nb.row && u.id !== unit.id);
@@ -422,6 +430,9 @@ function reconstructMovePath(fromCol, fromRow, toCol, toRow, unit) {
   const startKey = `${fromCol},${fromRow}`;
   visited.set(startKey, unit.moveLeft);
   parents.set(startKey, null);
+  const mpUt = UNIT_TYPES[unit.type];
+  const mpClass = mpUt ? mpUt.class : null;
+  const mpMods = mpClass ? UNIT_CLASS_TERRAIN_MODS[mpClass] : null;
 
   while (queue.length > 0) {
     const cur = queue.shift();
@@ -429,13 +440,14 @@ function reconstructMovePath(fromCol, fromRow, toCol, toRow, unit) {
     const neighbors = getHexNeighbors(cur.col, cur.row);
     for (const nb of neighbors) {
       const tile = game.map[nb.row][nb.col];
-      const cost = getTileMoveCost(tile);
+      const cost = getTileMoveCost(tile, mpClass);
       if (cost >= 99) continue;
       // River crossing uses all remaining MP (unless road bridge)
       const isRiverCross = crossesRiver(cur.col, cur.row, nb.col, nb.row)
                         && !roadBridgesRiver(cur.col, cur.row, nb.col, nb.row);
       const isRough = cost >= 2;
-      let remaining = (isRough || isRiverCross) ? 0 : (cur.move - cost);
+      const mpIgnoreRough = mpMods && mpMods.ignoreRoughPenalty;
+      let remaining = (isRiverCross || (isRough && !mpIgnoreRough)) ? 0 : (cur.move - cost);
 
       // ZOC: entering enemy ZOC ends movement
       if (isInEnemyZOC(nb.col, nb.row, unit.owner)) {


### PR DESCRIPTION
Scouts now ignore the rough terrain 'burns all moves' penalty (can keep moving through hills/woods/marsh). Cavalry and siege units pay 1.5x cost in rough terrain. Workers/settlers move faster on roads.

Adds UNIT_CLASS_TERRAIN_MODS table in constants.js and threads unit class through getTileMoveCost, computeMoveRange, computeRiverCrossings, and reconstructMovePath.