### PR TITLE
Fix end turn failing to advance, giving AI extra moves (#157)

### DIFF
--- a/src/turn.js
+++ b/src/turn.js
@@ -136,11 +136,11 @@ function calculateCityAmenities(events) {
 }
 
 let _processingTurn = false;
-let _lastReportedTurnError = 0; // rate-limit: one auto-report per game
+let _hasReportedTurnError = false; // rate-limit: one auto-report per game session
 
 function reportTurnError(section, turn, error) {
-  if (_lastReportedTurnError >= turn) return; // already reported this game
-  _lastReportedTurnError = turn;
+  if (_hasReportedTurnError) return;
+  _hasReportedTurnError = true;
   try {
     fetch(API + '/api/feedback', {
       method: 'POST',


### PR DESCRIPTION
## Summary
- **Root cause**: `game.turn++` sat inside a single `try` block covering ~750 lines of turn processing. Any exception after the individually try-caught AI processing prevented the turn from advancing, while AI actions had already executed — giving AI factions extra moves on every failed click.
- Wraps turn processing in an inner try-catch with `_turnSection` tracking (15 labeled sections) so `game.turn++` always executes regardless of downstream errors.
- Guards all 10 `FACTIONS[cid].name` accesses with optional chaining (`?.name || cid`) — these were the most likely crash sites.
- Auto-reports errors to `/api/feedback` with `[AUTO]` prefix for triage (rate-limited: one report per game session). Includes section name, turn number, stack trace, and game state snapshot.

Fixes #157, fixes #154

## Test plan
- [ ] Play through 30+ turns — end turn should always advance
- [ ] Verify AI factions don't get extra moves
- [ ] Check console for `[endTurn]` error logs if any section throws
- [ ] Verify `[AUTO]` feedback entries appear in the feedback table when errors occur
- [ ] Confirm no regression in turn processing (income, production, research, diplomacy all still work)