### PR TITLE
Fix conviction autofix workflow config

### DIFF
--- a/.github/workflows/conviction-autofix.yml
+++ b/.github/workflows/conviction-autofix.yml
@@ -105,6 +105,7 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
+      id-token: write
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       DIPLOMACY_REPO_TOKEN: ${{ secrets.DIPLOMACY_REPO_TOKEN }}
@@ -171,7 +172,6 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          max_turns: 100
           prompt: |
             You are implementing a fix/feature for issue #${{ steps.issue.outputs.number }} in the Uncivilised game.
 
@@ -234,7 +234,6 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          max_turns: 100
           prompt: |
             You are implementing a fix/feature for issue #${{ steps.issue.outputs.number }} in the Uncivilised game.
 


### PR DESCRIPTION
## Summary
- Add missing `id-token: write` permission needed for OIDC token fetch
- Remove invalid `max_turns` input (not supported by claude-code-action@v1)

## Test plan
- [ ] Trigger the conviction autofix workflow manually and verify it no longer fails at the OIDC token step

https://claude.ai/code/session_01JZABMLFk7HYUPkuGkqB9nc