### PR TITLE
fix: URL-encode + signs in Supabase query filters

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -211,7 +211,8 @@ def _sb_select(table: str, select: str = "*", filters: str = "",
         return []
     url = f"{_SB_REST}/{table}?select={quote(select)}"
     if filters:
-        url += f"&{filters}"
+        # URL-encode + signs in filter values (e.g. timezone +00:00)
+        url += f"&{filters.replace('+', '%2B')}"
     if order:
         url += f"&order={order}"
     if limit:


### PR DESCRIPTION
The _sb_select function was building URLs with unencoded + characters in timezone offsets (e.g. +00:00), which PostgREST interprets as spaces, causing 400 Bad Request errors on all analytics queries.