### PR TITLE
fix: unify war declaration across all hostile actions with ally escalation

### DIFF
--- a/src/combat.js
+++ b/src/combat.js
@@ -187,11 +187,88 @@ function isAtWarWith(factionId) {
 
 function declareSurpriseWar(factionId, factionName) {
   if (!game.aiWars) game.aiWars = [];
+  // Don't double-declare
+  if (isAtWarWith(factionId)) return;
   game.aiWars.push({ attacker: 'player', defender: factionId, startTurn: game.turn, turnsActive: 0 });
   const msg = `War declared on ${factionName}! (Surprise attack)`;
   addEvent(msg, 'diplomacy');
   showToast('War Declared', msg, 5000);
   logAction('diplomacy', msg, { type: 'player_surprise_attack', defender: factionId });
+
+  // Break all agreements with this faction
+  if (game.activeAlliances) delete game.activeAlliances[factionId];
+  if (game.tradeDeals) delete game.tradeDeals[factionId];
+  if (game.defensePacts) delete game.defensePacts[factionId];
+  if (game.marriages) delete game.marriages[factionId];
+  if (game.openBorders) delete game.openBorders[factionId];
+  if (game.ceasefires) delete game.ceasefires[factionId];
+  if (game.nonAggressionPacts) delete game.nonAggressionPacts[factionId];
+
+  // Pull in their formal allies (AI-AI alliances where the defender is a member)
+  const allies = (game.aiAlliances || [])
+    .filter(al => al.factions.includes(factionId))
+    .flatMap(al => al.factions.filter(f => f !== factionId && f !== 'player'));
+  for (const allyId of allies) {
+    if (isAtWarWith(allyId)) continue;
+    const allyFaction = FACTIONS[allyId];
+    const allyName = allyFaction ? allyFaction.name : allyId;
+    game.aiWars.push({ attacker: allyId, defender: 'player', startTurn: game.turn, turnsActive: 0 });
+    // Break agreements with ally too
+    if (game.activeAlliances) delete game.activeAlliances[allyId];
+    if (game.tradeDeals) delete game.tradeDeals[allyId];
+    if (game.defensePacts) delete game.defensePacts[allyId];
+    if (game.marriages) delete game.marriages[allyId];
+    if (game.openBorders) delete game.openBorders[allyId];
+    if (game.ceasefires) delete game.ceasefires[allyId];
+    if (game.nonAggressionPacts) delete game.nonAggressionPacts[allyId];
+    game.relationships[allyId] = Math.min(-50, (game.relationships[allyId] || 0) - 40);
+    addEvent(`${allyName} has joined the war against you! (Allied with ${factionName})`, 'diplomacy');
+    showToast('War Escalation', `${allyName} joins the war!`, 5000);
+  }
+}
+
+// Unified war confirmation — returns true if war was confirmed (or already at war)
+function confirmAndDeclareWar(factionId) {
+  if (isAtWarWith(factionId)) return true;
+
+  const faction = FACTIONS[factionId];
+  const factionName = faction ? faction.name : 'Unknown';
+
+  // Build list of agreements that would be broken
+  const agreements = [];
+  if (game.activeAlliances?.[factionId]) agreements.push('Alliance');
+  if (game.defensePacts?.[factionId]) agreements.push('Defense Pact');
+  if (game.nonAggressionPacts?.[factionId]) agreements.push('Non-Aggression Pact');
+  if (game.ceasefires?.[factionId]) agreements.push('Ceasefire');
+
+  // Build list of allies who would join the war
+  const allies = (game.aiAlliances || [])
+    .filter(al => al.factions.includes(factionId))
+    .flatMap(al => al.factions.filter(f => f !== factionId && f !== 'player'))
+    .filter(f => !isAtWarWith(f))
+    .map(f => FACTIONS[f]?.name || f);
+
+  let message = '';
+  if (agreements.length > 0) {
+    message = 'This will BREAK your agreements with ' + factionName + ':\n\n' +
+      '\u2022 ' + agreements.join('\n\u2022 ') + '\n\n';
+  }
+  message += 'This constitutes a surprise attack and declares war on ' + factionName + '.';
+  if (allies.length > 0) {
+    message += '\n\nTheir allies will also declare war on you:\n\u2022 ' + allies.join('\n\u2022 ');
+  }
+  message += '\n\nProceed?';
+
+  const agreed = confirm(message);
+  if (!agreed) return false;
+
+  game.relationships[factionId] = Math.min(-50, (game.relationships[factionId] || 0) - 50);
+  if (agreements.length > 0) {
+    addEvent('Peace broken with ' + factionName + '! (-50 relations)', 'diplomacy');
+  }
+
+  declareSurpriseWar(factionId, factionName);
+  return true;
 }
 
 function attackFactionCity(attacker, factionId) {
@@ -201,33 +278,7 @@ function attackFactionCity(attacker, factionId) {
   const factionName = faction ? faction.name : 'Unknown';
 
   // If not already at war, require confirmation and declare war first
-  if (!isAtWarWith(factionId)) {
-    const hasPeace = game.ceasefires[factionId] || game.nonAggressionPacts[factionId] ||
-                     game.activeAlliances[factionId] || game.defensePacts[factionId];
-    if (hasPeace) {
-      const agreements = [];
-      if (game.activeAlliances[factionId]) agreements.push('Alliance');
-      if (game.defensePacts[factionId]) agreements.push('Defense Pact');
-      if (game.nonAggressionPacts[factionId]) agreements.push('Non-Aggression Pact');
-      if (game.ceasefires[factionId]) agreements.push('Ceasefire');
-      const agreed = confirm(
-        'Attacking here will BREAK your agreements with ' + factionName + ':\n\n' +
-        '\u2022 ' + agreements.join('\n\u2022 ') + '\n\n' +
-        'This constitutes a surprise attack and declares war on ' + factionName + '.\n\nProceed?'
-      );
-      if (!agreed) return;
-      delete game.ceasefires[factionId];
-      delete game.nonAggressionPacts[factionId];
-      delete game.activeAlliances[factionId];
-      delete game.defensePacts[factionId];
-      game.relationships[factionId] = Math.min(-50, (game.relationships[factionId] || 0) - 50);
-      addEvent('Peace broken with ' + factionName + '! (-50 relations)', 'diplomacy');
-    } else {
-      const agreed = confirm('Are you sure? This will constitute a surprise attack and declare war on ' + factionName + '.');
-      if (!agreed) return;
-    }
-    declareSurpriseWar(factionId, factionName);
-  }
+  if (!confirmAndDeclareWar(factionId)) return;
 
   showBattlePanel(attacker, {
     type: 'city_garrison', hp: 100, col: fc.col, row: fc.row, owner: factionId,
@@ -288,33 +339,7 @@ function attackExpansionCity(attacker, factionId, cityIdx) {
   const factionName = faction ? faction.name : 'Unknown';
 
   // If not already at war, require confirmation and declare war first
-  if (!isAtWarWith(factionId)) {
-    const hasPeace = game.ceasefires[factionId] || game.nonAggressionPacts[factionId] ||
-                     game.activeAlliances[factionId] || game.defensePacts[factionId];
-    if (hasPeace) {
-      const agreements = [];
-      if (game.activeAlliances[factionId]) agreements.push('Alliance');
-      if (game.defensePacts[factionId]) agreements.push('Defense Pact');
-      if (game.nonAggressionPacts[factionId]) agreements.push('Non-Aggression Pact');
-      if (game.ceasefires[factionId]) agreements.push('Ceasefire');
-      const agreed = confirm(
-        'Attacking here will BREAK your agreements with ' + factionName + ':\n\n' +
-        '\u2022 ' + agreements.join('\n\u2022 ') + '\n\n' +
-        'This constitutes a surprise attack and declares war on ' + factionName + '.\n\nProceed?'
-      );
-      if (!agreed) return;
-      delete game.ceasefires[factionId];
-      delete game.nonAggressionPacts[factionId];
-      delete game.activeAlliances[factionId];
-      delete game.defensePacts[factionId];
-      game.relationships[factionId] = Math.min(-50, (game.relationships[factionId] || 0) - 50);
-      addEvent('Peace broken with ' + factionName + '! (-50 relations)', 'diplomacy');
-    } else {
-      const agreed = confirm('Are you sure? This will constitute a surprise attack and declare war on ' + factionName + '.');
-      if (!agreed) return;
-    }
-    declareSurpriseWar(factionId, factionName);
-  }
+  if (!confirmAndDeclareWar(factionId)) return;
 
   showBattlePanel(attacker, {
     type: 'city_garrison', hp: ec.hp || CITY_DEFENSE.BASE_HP, col: ec.col, row: ec.row, owner: factionId,
@@ -871,6 +896,7 @@ export {
   resolveCombat,
   isAtWarWith,
   declareSurpriseWar,
+  confirmAndDeclareWar,
   attackFactionCity,
   computeCityDefense,
   attackExpansionCity,

--- a/src/ui-panels.js
+++ b/src/ui-panels.js
@@ -8,7 +8,7 @@ import { addEvent, logAction, showToast, showCompletionNotification } from './ev
 import { selectUnit, deselectUnit, applyPromotion, upgradeUnit, selectNextUnit, moveUnitTo } from './units.js';
 import { getRelationLabel } from './diplomacy-api.js';
 import { getModCombatBonus } from './diplomacy-api.js';
-import { isAtWarWith, declareSurpriseWar } from './combat.js';
+import { isAtWarWith, declareSurpriseWar, confirmAndDeclareWar } from './combat.js';
 import { showWorkerActions, showSettlerActions } from './improvements.js';
 import { updateUI, updateEnvoyUI } from './leaderboard.js';
 import { autoSelectNext, computeAttackRange } from './units.js';
@@ -1399,36 +1399,7 @@ window.unitAction = function(action) {
       if (tileOwner) {
         const ownerName = FACTIONS[tileOwner] ? FACTIONS[tileOwner].name : tileOwner;
         if (!isAtWarWith(tileOwner)) {
-          const hasPeace = game.ceasefires[tileOwner] || game.nonAggressionPacts[tileOwner] ||
-                           game.activeAlliances[tileOwner] || game.defensePacts[tileOwner];
-          if (hasPeace) {
-            const agreements = [];
-            if (game.activeAlliances[tileOwner]) agreements.push('Alliance');
-            if (game.defensePacts[tileOwner]) agreements.push('Defense Pact');
-            if (game.nonAggressionPacts[tileOwner]) agreements.push('Non-Aggression Pact');
-            if (game.ceasefires[tileOwner]) agreements.push('Ceasefire');
-            const agreed = confirm(
-              'Pillaging here will BREAK your agreements with ' + ownerName + ':\n\n' +
-              '\u2022 ' + agreements.join('\n\u2022 ') + '\n\n' +
-              'This constitutes a surprise attack and declares war on ' + ownerName + '.\n\nProceed?'
-            );
-            if (!agreed) break;
-            delete game.ceasefires[tileOwner];
-            delete game.nonAggressionPacts[tileOwner];
-            delete game.activeAlliances[tileOwner];
-            delete game.defensePacts[tileOwner];
-            delete game.openBorders[tileOwner];
-            game.relationships[tileOwner] = Math.min(-50, (game.relationships[tileOwner] || 0) - 50);
-            for (const fid of Object.keys(game.relationships)) {
-              if (fid !== tileOwner) game.relationships[fid] = (game.relationships[fid] || 0) - 10;
-            }
-            addEvent('\u{26A0} Peace broken with ' + ownerName + '! (-50 relations, -10 with all others)', 'diplomacy');
-            logAction('diplomacy', 'Broke peace with ' + ownerName + ' by pillaging', { factionId: tileOwner });
-          } else {
-            const agreed = confirm('Are you sure? This will constitute a surprise attack and declare war on ' + ownerName + '.');
-            if (!agreed) break;
-          }
-          declareSurpriseWar(tileOwner, ownerName);
+          if (!confirmAndDeclareWar(tileOwner)) break;
         }
       }
       let reward = '';

--- a/src/units.js
+++ b/src/units.js
@@ -2,7 +2,7 @@ import { MAP_COLS, MAP_ROWS, BASE_TERRAIN, UNIT_TYPES, UNIT_UPGRADES, UNIT_UNLOC
 import { game, getNextUnitId } from './state.js';
 import { hexToPixel, pixelToHex, getHexNeighbors, hexDistance } from './hex.js';
 import { getTileMoveCost, isTilePassable, crossesRiver, roadBridgesRiver } from './map.js';
-import { resolveCombat, isAtWarWith, declareSurpriseWar, attackFactionCity, attackExpansionCity, getUnitAt, getPlayerUnitAt, getEnemyUnitAt, getCityAt, showBattlePanel, applyTacticModifier } from './combat.js';
+import { resolveCombat, isAtWarWith, declareSurpriseWar, confirmAndDeclareWar, attackFactionCity, attackExpansionCity, getUnitAt, getPlayerUnitAt, getEnemyUnitAt, getCityAt, showBattlePanel, applyTacticModifier } from './combat.js';
 import { showSelectionPanel, hideSelectionPanel, showCityPanel, showTileInfo, showCombatResult } from './ui-panels.js';
 import { showWorkerActions, showSettlerActions, moveTowardWaypoint } from './improvements.js';
 import { render, markVisibilityDirty } from './render.js';
@@ -623,11 +623,7 @@ function handleHexClick(col, row) {
         if (target) {
           // Surprise attack check: non-barbarian units belonging to a faction we're not at war with
           if (target.owner !== 'barbarian' && !isAtWarWith(target.owner)) {
-            const faction = FACTIONS[target.owner];
-            const factionName = faction ? faction.name : target.owner;
-            const agreed = confirm('Are you sure? This will constitute a surprise attack and declare war on ' + factionName + '.');
-            if (!agreed) return;
-            declareSurpriseWar(target.owner, factionName);
+            if (!confirmAndDeclareWar(target.owner)) return;
           }
           // Civilian units (workers, settlers) are captured, not fought
           const targetType = UNIT_TYPES[target.type];

--- a/tests/war-declaration.test.js
+++ b/tests/war-declaration.test.js
@@ -1,0 +1,155 @@
+import { describe, test, expect, beforeEach, vi } from 'vitest';
+import { setupGameState, makeUnit } from './fixtures.js';
+import { game } from '../src/state.js';
+
+// Mock modules that touch the DOM
+vi.mock('../src/leaderboard.js', () => ({ updateUI: vi.fn() }));
+vi.mock('../src/render.js', () => ({ render: vi.fn(), markVisibilityDirty: vi.fn() }));
+vi.mock('../src/discovery.js', () => ({ revealAround: vi.fn() }));
+vi.mock('../src/feedback.js', () => ({ startAnimLoop: vi.fn() }));
+vi.mock('../src/input.js', () => ({ panCameraTo: vi.fn() }));
+
+import { isAtWarWith, declareSurpriseWar, confirmAndDeclareWar } from '../src/combat.js';
+
+describe('isAtWarWith()', () => {
+  beforeEach(() => {
+    setupGameState({ aiWars: [] });
+  });
+
+  test('should return false when not at war', () => {
+    expect(isAtWarWith('faction_a')).toBe(false);
+  });
+
+  test('should return true when player is attacker', () => {
+    game.aiWars.push({ attacker: 'player', defender: 'faction_a', startTurn: 1, turnsActive: 0 });
+    expect(isAtWarWith('faction_a')).toBe(true);
+  });
+
+  test('should return true when player is defender', () => {
+    game.aiWars.push({ attacker: 'faction_a', defender: 'player', startTurn: 1, turnsActive: 0 });
+    expect(isAtWarWith('faction_a')).toBe(true);
+  });
+});
+
+describe('declareSurpriseWar()', () => {
+  beforeEach(() => {
+    setupGameState({
+      aiWars: [],
+      relationships: { faction_a: 0, faction_b: 10 },
+      activeAlliances: { faction_a: true },
+      tradeDeals: { faction_a: { gold: 5 } },
+      ceasefires: { faction_a: { startTurn: 1, duration: 10 } },
+      nonAggressionPacts: {},
+      defensePacts: {},
+      aiAlliances: [],
+    });
+  });
+
+  test('should add war entry to aiWars', () => {
+    declareSurpriseWar('faction_a', 'Test Faction');
+    expect(game.aiWars.length).toBe(1);
+    expect(game.aiWars[0].attacker).toBe('player');
+    expect(game.aiWars[0].defender).toBe('faction_a');
+  });
+
+  test('should not double-declare war', () => {
+    declareSurpriseWar('faction_a', 'Test Faction');
+    declareSurpriseWar('faction_a', 'Test Faction');
+    expect(game.aiWars.length).toBe(1);
+  });
+
+  test('should break all agreements with target faction', () => {
+    declareSurpriseWar('faction_a', 'Test Faction');
+    expect(game.activeAlliances.faction_a).toBeUndefined();
+    expect(game.tradeDeals.faction_a).toBeUndefined();
+    expect(game.ceasefires.faction_a).toBeUndefined();
+  });
+
+  test('should pull in allies of the target faction', () => {
+    game.aiAlliances = [{ factions: ['faction_a', 'faction_b'], turn: 1 }];
+    declareSurpriseWar('faction_a', 'Test Faction');
+    // faction_b should also be at war with player now
+    expect(isAtWarWith('faction_b')).toBe(true);
+  });
+
+  test('should not pull in allies already at war', () => {
+    game.aiAlliances = [{ factions: ['faction_a', 'faction_b'], turn: 1 }];
+    game.aiWars.push({ attacker: 'faction_b', defender: 'player', startTurn: 1, turnsActive: 0 });
+    declareSurpriseWar('faction_a', 'Test Faction');
+    // Should only have the existing war + the new one, not a duplicate for faction_b
+    const bWars = game.aiWars.filter(w =>
+      (w.attacker === 'faction_b' && w.defender === 'player') ||
+      (w.attacker === 'player' && w.defender === 'faction_b')
+    );
+    expect(bWars.length).toBe(1);
+  });
+
+  test('should break agreements with pulled-in allies', () => {
+    game.aiAlliances = [{ factions: ['faction_a', 'faction_b'], turn: 1 }];
+    game.activeAlliances.faction_b = true;
+    game.ceasefires.faction_b = { startTurn: 1, duration: 10 };
+    declareSurpriseWar('faction_a', 'Test Faction');
+    expect(game.activeAlliances.faction_b).toBeUndefined();
+    expect(game.ceasefires.faction_b).toBeUndefined();
+  });
+
+  test('should damage relationships with pulled-in allies', () => {
+    game.aiAlliances = [{ factions: ['faction_a', 'faction_b'], turn: 1 }];
+    game.relationships.faction_b = 10;
+    declareSurpriseWar('faction_a', 'Test Faction');
+    expect(game.relationships.faction_b).toBeLessThanOrEqual(-30);
+  });
+});
+
+describe('confirmAndDeclareWar()', () => {
+  beforeEach(() => {
+    setupGameState({
+      aiWars: [],
+      relationships: { faction_a: 0 },
+      activeAlliances: {},
+      tradeDeals: {},
+      ceasefires: {},
+      nonAggressionPacts: {},
+      defensePacts: {},
+      aiAlliances: [],
+    });
+  });
+
+  test('should return true if already at war (no confirmation needed)', () => {
+    game.aiWars.push({ attacker: 'player', defender: 'faction_a', startTurn: 1, turnsActive: 0 });
+    const result = confirmAndDeclareWar('faction_a');
+    expect(result).toBe(true);
+  });
+
+  test('should return false if user declines confirmation', () => {
+    globalThis.confirm = vi.fn(() => false);
+    const result = confirmAndDeclareWar('faction_a');
+    expect(result).toBe(false);
+    expect(isAtWarWith('faction_a')).toBe(false);
+  });
+
+  test('should declare war if user confirms', () => {
+    globalThis.confirm = vi.fn(() => true);
+    const result = confirmAndDeclareWar('faction_a');
+    expect(result).toBe(true);
+    expect(isAtWarWith('faction_a')).toBe(true);
+  });
+
+  test('should mention allies in confirmation message', () => {
+    game.aiAlliances = [{ factions: ['faction_a', 'faction_b'], turn: 1 }];
+    globalThis.confirm = vi.fn(() => true);
+    confirmAndDeclareWar('faction_a');
+    const msg = globalThis.confirm.mock.calls[0][0];
+    expect(msg).toContain('allies');
+  });
+
+  test('should mention agreements in confirmation message', () => {
+    game.activeAlliances.faction_a = true;
+    game.ceasefires.faction_a = { startTurn: 1, duration: 10 };
+    globalThis.confirm = vi.fn(() => true);
+    confirmAndDeclareWar('faction_a');
+    const msg = globalThis.confirm.mock.calls[0][0];
+    expect(msg).toContain('Alliance');
+    expect(msg).toContain('Ceasefire');
+  });
+});


### PR DESCRIPTION
## Summary

- All hostile actions (attacking units, cities, pillaging) now use a single `confirmAndDeclareWar()` that shows a unified confirmation dialog
- Confirmation lists broken agreements AND allies who will join the war against you
- `declareSurpriseWar()` now pulls in the target's formal allies (from `aiAlliances`), breaks agreements with them, and prevents double-declaration
- Once at war, no confirmation is shown — attacks/pillaging proceed immediately

## What changed

| Action | Before | After |
|---|---|---|
| Attack unit | Basic confirm, no agreement handling, no allies | Full confirm with agreements + allies |
| Attack city | Inline agreement check, no allies | Unified confirm with allies |
| Pillage improvement | Duplicate inline agreement logic, no allies | Unified confirm with allies |
| Already at war | Skipped (correct) | Skipped (correct) |
| Ally escalation | Never happened | Allies auto-declare war on you |

## Test plan

- [x] All 188 tests pass (`npm test`)
- [x] Build succeeds (`npm run build`)
- [ ] Manual: attack a unit of a faction you're not at war with — confirm dialog appears
- [ ] Manual: once at war, attack again — no dialog, attack proceeds
- [ ] Manual: attack faction with an ally — ally joins war
- [ ] Manual: pillage improvement — same confirmation flow

https://claude.ai/code/session_01HBQaWuNQnWwa8JzxP3qMaL