### PR TITLE
Fix: attacker moves onto captured civilian's tile

### DIFF
--- a/src/combat.js
+++ b/src/combat.js
@@ -21,11 +21,14 @@ function resolveCombat(attacker, defender) {
   const aType = UNIT_TYPES[attacker.type];
   const dType = UNIT_TYPES[defender.type] || { name: 'City', combat: 15, rangedCombat: 0, range: 0, movePoints: 0, icon: '\u{1F3F0}', class: 'city', desc: 'Fortified city' };
 
-  // Civilian capture — attacker takes ownership instead of fighting
+  // Civilian capture — attacker takes ownership and moves onto the tile
   if (dType.class === 'civilian') {
     const prevOwner = defender.owner;
     defender.owner = attacker.owner;
     defender.moveLeft = 0;
+    // Move attacker onto captured unit's tile (military + civilian can stack)
+    attacker.col = defender.col;
+    attacker.row = defender.row;
     const ownerName = FACTIONS[prevOwner]?.name || prevOwner;
     const captorName = FACTIONS[attacker.owner]?.name || attacker.owner;
     if (prevOwner === 'player') {

--- a/src/units.js
+++ b/src/units.js
@@ -631,6 +631,9 @@ function handleHexClick(col, row) {
             const prevOwner = target.owner;
             target.owner = 'player';
             target.moveLeft = 0;
+            // Move attacker onto the captured unit's tile (military + civilian can stack)
+            unit.col = target.col;
+            unit.row = target.row;
             const ownerName = FACTIONS[prevOwner] ? FACTIONS[prevOwner].name : prevOwner;
             addEvent(`Captured ${targetType.name} from ${ownerName}!`, 'combat');
             showToast('Unit Captured', `${targetType.name} captured from ${ownerName}!`);


### PR DESCRIPTION
When capturing a worker or settler, the attacker now moves onto the target's hex and stacks with the newly captured unit (military + civilian stacking is already supported). Previously the attacker stayed on its original tile, leaving the captured unit stranded.

Fixed in both code paths: player captures (units.js handleHexClick) and AI captures (combat.js resolveCombat).