### PR TITLE
fix: units spawn at the city that built them, not always the capital

### DIFF
--- a/src/save-load.js
+++ b/src/save-load.js
@@ -37,6 +37,7 @@ function migrateTiles(state) {
 
   if (state.currentUnitBuild === undefined) state.currentUnitBuild = null;
   if (state.unitBuildProgress === undefined) state.unitBuildProgress = 0;
+  if (state.unitBuildCityIdx === undefined) state.unitBuildCityIdx = 0;
   if (state.factionCities) {
     for (const fc of Object.values(state.factionCities)) {
       if (fc.hp === undefined) fc.hp = 100;

--- a/src/turn.js
+++ b/src/turn.js
@@ -496,30 +496,42 @@ function endTurn() {
     game.unitBuildProgress += prodThisTurn;
     const ut = UNIT_TYPES[game.currentUnitBuild];
     if (ut && game.unitBuildProgress >= ut.cost) {
-      const city = game.cities[0];
-      const neighbors = getHexNeighbors(city.col, city.row);
+      // Place unit near the city that started the build (fallback to any city with room)
+      const buildCityIdx = game.unitBuildCityIdx || 0;
+      const cityOrder = [...game.cities];
+      // Put the build city first, then try others
+      if (buildCityIdx > 0 && buildCityIdx < cityOrder.length) {
+        const buildCity = cityOrder.splice(buildCityIdx, 1)[0];
+        cityOrder.unshift(buildCity);
+      }
       let placed = false;
-      for (const nb of neighbors) {
-        const tile = game.map[nb.row][nb.col];
-        if (!isTilePassable(tile)) continue;
-        if (getUnitAt(nb.col, nb.row)) continue;
-        const newUnit = createUnit(game.currentUnitBuild, nb.col, nb.row, 'player');
-        newUnit.moveLeft = 0;
-        game.units.push(newUnit);
-        game.military += Math.floor(ut.combat / 4);
-        placed = true;
-        break;
+      let placedCity = null;
+      for (const city of cityOrder) {
+        const neighbors = getHexNeighbors(city.col, city.row);
+        for (const nb of neighbors) {
+          const tile = game.map[nb.row][nb.col];
+          if (!isTilePassable(tile)) continue;
+          if (getUnitAt(nb.col, nb.row)) continue;
+          const newUnit = createUnit(game.currentUnitBuild, nb.col, nb.row, 'player');
+          newUnit.moveLeft = 0;
+          game.units.push(newUnit);
+          game.military += Math.floor(ut.combat / 4);
+          placed = true;
+          placedCity = city;
+          break;
+        }
+        if (placed) break;
       }
       if (placed) {
         if (game.currentUnitBuild === 'settler') {
           game.population = Math.max(500, game.population - 500);
-          const mc = game.cities[0];
-          if (mc) mc.population = Math.max(500, (mc.population || game.population) - 500);
+          if (placedCity) placedCity.population = Math.max(500, (placedCity.population || game.population) - 500);
         }
         events.push(`${ut.name} trained!`);
-        addEvent(`${ut.name} trained!`, 'combat');
+        addEvent(`${ut.name} trained in ${placedCity ? placedCity.name : 'city'}!`, 'combat');
         game.currentUnitBuild = null;
         game.unitBuildProgress = 0;
+        game.unitBuildCityIdx = 0;
         showCompletionNotification('unit', ut.name, ut.desc);
         if (typeof showToast === 'function') showToast('\u2694 Unit Ready', ut.name + ' trained!');
       } else {

--- a/src/ui-panels.js
+++ b/src/ui-panels.js
@@ -1,6 +1,6 @@
-import { UNIT_TYPES, UNIT_UPGRADES, UNIT_UNLOCKS, UNIT_PROMOTIONS, PROMOTION_PATHS, PROMOTION_XP_THRESHOLDS, BUILDINGS, TECHNOLOGIES, CIVICS, GOVERNMENTS, WONDERS, FACTIONS, BASE_TERRAIN, RESOURCES, TILE_IMPROVEMENTS, MAX_TURNS, goldCost, UNIT_MAINTENANCE, CITY_DEFENSE } from './constants.js';
+import { UNIT_TYPES, UNIT_UPGRADES, UNIT_UNLOCKS, UNIT_PROMOTIONS, PROMOTION_PATHS, PROMOTION_XP_THRESHOLDS, BUILDINGS, TECHNOLOGIES, CIVICS, GOVERNMENTS, WONDERS, FACTIONS, BASE_TERRAIN, RESOURCES, TILE_IMPROVEMENTS, MAX_TURNS, goldCost, UNIT_MAINTENANCE, CITY_DEFENSE, HEX_SIZE, SQRT3 } from './constants.js';
 import { getNextUnitId } from './state.js';
-import { game } from './state.js';
+import { game, canvasW, canvasH, gameZoom } from './state.js';
 import { hexToPixel, hexDistance } from './hex.js';
 import { getTileYields, getTileName, isResourceRevealed } from './map.js';
 import { render } from './render.js';
@@ -530,6 +530,19 @@ function switchProduction(startFn) {
   startFn();
 }
 
+function getNearestCityIndex() {
+  if (game.cities.length <= 1) return 0;
+  // Find city closest to camera center
+  const camCenterCol = Math.floor((game.cameraX + (canvasW / 2) / gameZoom) / (HEX_SIZE * SQRT3));
+  const camCenterRow = Math.floor((game.cameraY + (canvasH / 2) / gameZoom) / (HEX_SIZE * 1.5));
+  let bestIdx = 0, bestDist = Infinity;
+  for (let i = 0; i < game.cities.length; i++) {
+    const d = hexDistance(camCenterCol, camCenterRow, game.cities[i].col, game.cities[i].row);
+    if (d < bestDist) { bestDist = d; bestIdx = i; }
+  }
+  return bestIdx;
+}
+
 function recruitUnit(typeId) {
   const ut = UNIT_TYPES[typeId];
   if (typeId === 'settler' && game.population < 2000) {
@@ -539,9 +552,12 @@ function recruitUnit(typeId) {
   const doRecruit = () => {
     game.currentUnitBuild = typeId;
     game.unitBuildProgress = 0;
+    // Track which city is building (closest to camera center)
+    game.unitBuildCityIdx = getNearestCityIndex();
     const turnsNeeded = Math.ceil(ut.cost / Math.max(1, game.productionPerTurn));
-    logAction('build', 'Started training ' + ut.name, { unitType: typeId });
-    addEvent('Training ' + ut.name + ' (' + turnsNeeded + ' turns)', 'combat');
+    const buildCityName = game.cities[game.unitBuildCityIdx]?.name || 'city';
+    logAction('build', 'Started training ' + ut.name + ' in ' + buildCityName, { unitType: typeId });
+    addEvent('Training ' + ut.name + ' in ' + buildCityName + ' (' + turnsNeeded + ' turns)', 'combat');
     if (typeId === 'settler') addEvent('Settler will consume 500 population when complete', 'gold');
     updateUI();
     closeAllPanels();


### PR DESCRIPTION
Units now spawn near the city that started the build (based on camera position), not always the capital. Falls back to any city with room.\n\nhttps://claude.ai/code/session_01HBQaWuNQnWwa8JzxP3qMaL