### PR TITLE
fix: allow activating fortified/sleeping units and cycle units in cities

### DIFF
--- a/src/input.js
+++ b/src/input.js
@@ -161,6 +161,13 @@ export function initInputHandlers() {
           const sel = game.selectedUnitId && game.units.find(u => u.id === game.selectedUnitId);
           if (sel) { panCameraTo(sel.col, sel.row); render(); }
         }
+        else if (key === 'w') {
+          e.preventDefault();
+          const sel = game.selectedUnitId && game.units.find(u => u.id === game.selectedUnitId);
+          if (sel && sel.owner === 'player' && (sel.fortified || sel.sleeping)) {
+            window.unitAction('activate');
+          }
+        }
       }
     }
     // Escape key closes any open panel or overlay

--- a/src/ui-panels.js
+++ b/src/ui-panels.js
@@ -99,6 +99,10 @@ function showSelectionPanel(unit) {
       const newDef = UNIT_TYPES[upg.to];
       html += '<button class="sel-btn" style="border-color:' + (canAfford ? '#4a9' : '#666') + ';opacity:' + (canAfford ? '1' : '0.5') + '" ' + (canAfford ? 'onclick="upgradeUnit(' + unit.id + ')"' : 'disabled') + '><span>' + (newDef ? newDef.icon : '') + ' Upgrade to ' + (newDef ? newDef.name : upg.to) + ' (' + upg.cost + 'g)</span></button>';
     }
+    // Activate button for fortified/sleeping units
+    if (unit.fortified || unit.sleeping) {
+      html += `<button class="sel-btn" style="border-color:#6aab5c" onclick="unitAction('activate')"><span>\u{26A1} Activate</span><span class="sel-key">W</span></button>`;
+    }
     if (unit.moveLeft > 0) {
       html += `<button class="sel-btn" onclick="unitAction('skip')"><span>Skip</span><span class="sel-key">S</span></button>`;
       if (!unit.fortified) {
@@ -1372,6 +1376,14 @@ window.unitAction = function(action) {
   const ut = UNIT_TYPES[unit.type];
 
   switch (action) {
+    case 'activate':
+      unit.fortified = false;
+      unit.sleeping = false;
+      unit.alert = false;
+      addEvent(`${ut.name} activated`, '');
+      showSelectionPanel(unit);
+      render();
+      return;
     case 'cancelWaypoint':
       unit.waypoint = null;
       addEvent(`${ut.name} journey cancelled`, '');

--- a/src/units.js
+++ b/src/units.js
@@ -712,19 +712,34 @@ function handleHexClick(col, row) {
 
     // Check what's at this hex — cycle through stacked units on repeat clicks
     const unitsHere = game.units.filter(u => u.col === col && u.row === row);
-    if (unitsHere.length > 0) {
-      if (unitsHere.length === 1) {
-        selectUnit(unitsHere[0]);
+    const playerUnitsHere = unitsHere.filter(u => u.owner === 'player');
+    const cityHere = getCityAt(col, row);
+
+    if (playerUnitsHere.length > 0) {
+      // If a player unit is already selected here, cycle: next unit or city
+      const currentlySelected = playerUnitsHere.find(u => u.id === game.selectedUnitId);
+      if (currentlySelected) {
+        const nextUnit = playerUnitsHere.find(u => u.id !== game.selectedUnitId);
+        if (nextUnit) {
+          selectUnit(nextUnit);
+        } else if (cityHere && cityHere.owner === 'player') {
+          // Cycled through all units — show city panel
+          deselectUnit();
+          game.selectedHex = { col, row };
+          showCityPanel(cityHere);
+        } else {
+          selectUnit(playerUnitsHere[0]);
+        }
       } else {
-        // Multiple units stacked — cycle: pick the one that ISN'T currently selected
-        const other = unitsHere.find(u => u.id !== game.selectedUnitId);
-        selectUnit(other || unitsHere[0]);
+        selectUnit(playerUnitsHere[0]);
       }
+      return;
+    } else if (unitsHere.length > 0) {
+      selectUnit(unitsHere[0]);
       return;
     }
 
-    // Check for city
-    const cityHere = getCityAt(col, row);
+    // Check for city (no player units on tile)
     if (cityHere) {
       deselectUnit();
       game.selectedHex = { col, row };


### PR DESCRIPTION
- Clicking a city tile with player units now shows the unit first, cycles through units, then city panel\n- Added Activate button (W key) to wake fortified/sleeping units\n- Previously fortified units in cities were inaccessible\n\nhttps://claude.ai/code/session_01HBQaWuNQnWwa8JzxP3qMaL