### PR TITLE
fix: C key auto-selects next movable unit if none selected

### DIFF
--- a/src/input.js
+++ b/src/input.js
@@ -152,7 +152,12 @@ export function initInputHandlers() {
         else if (key === 'a') { e.preventDefault(); togglePanel('advisor-panel'); }
         else if (key === 'c') {
           e.preventDefault();
-          const sel = game.selectedUnitId && game.units.find(u => u.id === game.selectedUnitId);
+          let sel = game.selectedUnitId && game.units.find(u => u.id === game.selectedUnitId);
+          // If no unit selected, auto-select next movable unit
+          if (!sel) {
+            selectNextUnit();
+            sel = game.selectedUnitId && game.units.find(u => u.id === game.selectedUnitId);
+          }
           if (sel) { panCameraTo(sel.col, sel.row); render(); }
         }
         else if (key === ' ') {


### PR DESCRIPTION
C key now auto-selects the next movable unit if none is selected, then centers camera on it. Previously only worked if a unit was already selected.\n\nhttps://claude.ai/code/session_01HBQaWuNQnWwa8JzxP3qMaL