### PR TITLE
fix: ranged units can bombard at distance without moving

### DIFF
--- a/src/combat.js
+++ b/src/combat.js
@@ -21,14 +21,16 @@ function resolveCombat(attacker, defender) {
   const aType = UNIT_TYPES[attacker.type];
   const dType = UNIT_TYPES[defender.type] || { name: 'City', combat: 15, rangedCombat: 0, range: 0, movePoints: 0, icon: '\u{1F3F0}', class: 'city', desc: 'Fortified city' };
 
-  // Civilian capture — attacker takes ownership and moves onto the tile
+  // Civilian capture — attacker takes ownership
   if (dType.class === 'civilian') {
     const prevOwner = defender.owner;
     defender.owner = attacker.owner;
     defender.moveLeft = 0;
-    // Move attacker onto captured unit's tile (military + civilian can stack)
-    attacker.col = defender.col;
-    attacker.row = defender.row;
+    // Only melee units move onto the captured unit's tile (ranged stay put)
+    if (aType.rangedCombat <= 0 || aType.range <= 0) {
+      attacker.col = defender.col;
+      attacker.row = defender.row;
+    }
     const ownerName = FACTIONS[prevOwner]?.name || prevOwner;
     const captorName = FACTIONS[attacker.owner]?.name || attacker.owner;
     if (prevOwner === 'player') {
@@ -157,8 +159,12 @@ function resolveCombat(attacker, defender) {
     }
   }
 
-  // Use movement points
-  attacker.moveLeft = 0;
+  // Use movement points — ranged units can still move after attacking
+  if (aType.rangedCombat > 0 && aType.range > 0) {
+    attacker.moveLeft = Math.max(0, attacker.moveLeft - 1);
+  } else {
+    attacker.moveLeft = 0;
+  }
   attacker.hasAttackedThisTurn = true;
 
   // --- XP and Promotion ---

--- a/src/constants.js
+++ b/src/constants.js
@@ -56,7 +56,7 @@ export const TERRAIN_FEATURES = {
 export let UNIT_TYPES = {
   scout:     { name: 'Scout',         cost: 15, combat: 10, rangedCombat: 0, range: 0, movePoints: 3, icon: '👁', class: 'recon',    desc: 'Fast explorer, weak in combat' },
   warrior:   { name: 'Warrior',       cost: 20, combat: 20, rangedCombat: 0, range: 0, movePoints: 2, icon: '⚔', class: 'melee',    desc: 'Basic melee infantry' },
-  slinger:   { name: 'Slinger',       cost: 20, combat: 5,  rangedCombat: 15,range: 1, movePoints: 2, icon: '◎', class: 'ranged',   desc: 'Cheap ranged unit' },
+  slinger:   { name: 'Slinger',       cost: 20, combat: 5,  rangedCombat: 15,range: 2, movePoints: 2, icon: '◎', class: 'ranged',   desc: 'Cheap ranged unit, range 2' },
   archer:    { name: 'Archer',        cost: 30, combat: 15, rangedCombat: 25,range: 2, movePoints: 2, icon: '🏹', class: 'ranged',   desc: 'Strong ranged attacker, range 2' },
   spearman:  { name: 'Spearman',      cost: 35, combat: 25, rangedCombat: 0, range: 0, movePoints: 2, icon: '🔱', class: 'anti-cav', desc: '+10 vs cavalry units' },
   chariot:   { name: 'Heavy Chariot', cost: 40, combat: 28, rangedCombat: 0, range: 0, movePoints: 2, icon: '🐎', class: 'cavalry',  desc: 'Powerful mobile unit' },

--- a/src/units.js
+++ b/src/units.js
@@ -631,9 +631,12 @@ function handleHexClick(col, row) {
             const prevOwner = target.owner;
             target.owner = 'player';
             target.moveLeft = 0;
-            // Move attacker onto the captured unit's tile (military + civilian can stack)
-            unit.col = target.col;
-            unit.row = target.row;
+            // Only melee units move onto the captured unit's tile
+            const attackerType = UNIT_TYPES[unit.type];
+            if (!attackerType || attackerType.rangedCombat <= 0 || attackerType.range <= 0) {
+              unit.col = target.col;
+              unit.row = target.row;
+            }
             const ownerName = FACTIONS[prevOwner] ? FACTIONS[prevOwner].name : prevOwner;
             addEvent(`Captured ${targetType.name} from ${ownerName}!`, 'combat');
             showToast('Unit Captured', `${targetType.name} captured from ${ownerName}!`);


### PR DESCRIPTION
- Slinger range 1→2 (was effectively melee)\n- Ranged units stay put when capturing/attacking (no teleport to target tile)\n- Ranged units spend 1 move on attack, can still move after (Civ behavior)\n\nhttps://claude.ai/code/session_01HBQaWuNQnWwa8JzxP3qMaL