### PR TITLE
fix: purchased units spawn on adjacent tile instead of on city tile

### DIFF
--- a/src/ui-panels.js
+++ b/src/ui-panels.js
@@ -960,9 +960,24 @@ function purchaseUnit(typeId) {
   game.gold -= cost;
   const cityIdx = getNearestCityIndex();
   const city = game.cities[cityIdx] || game.cities[0];
+  // Place on adjacent tile (not on city tile) — same as production-built units
+  let spawnCol = city.col, spawnRow = city.row;
+  const neighbors = getHexNeighbors(city.col, city.row);
+  for (const nb of neighbors) {
+    const t = game.map[nb.row]?.[nb.col];
+    if (!t) continue;
+    const bi = BASE_TERRAIN[t.base];
+    if (!bi || !bi.movable) continue;
+    if (t.feature === 'mountain') continue;
+    const occupied = game.units.some(u => u.col === nb.col && u.row === nb.row && u.owner === 'player' && UNIT_TYPES[u.type]?.combat > 0);
+    if (occupied) continue;
+    spawnCol = nb.col;
+    spawnRow = nb.row;
+    break;
+  }
   const unitId = getNextUnitId();
   const newUnit = {
-    id: unitId, type: typeId, col: city.col, row: city.row,
+    id: unitId, type: typeId, col: spawnCol, row: spawnRow,
     owner: 'player', hp: 100, moveLeft: 0,
     xp: 0, level: 1, fortified: false, sleeping: false
   };


### PR DESCRIPTION
Gold-purchased units now spawn on a free adjacent tile instead of on the city hex. Fixes the frozen/unselectable unit bug where units spawned on the city tile were hidden behind the city panel.\n\nhttps://claude.ai/code/session_01HBQaWuNQnWwa8JzxP3qMaL