### PR TITLE
fix: rumours tab shows full history including purchased intel

### DIFF
--- a/src/ai-diplomacy.js
+++ b/src/ai-diplomacy.js
@@ -500,25 +500,17 @@ function applyRelationDrift(factionIds) {
 function processRumourQueue() {
   if (!game.rumourQueue || game.rumourQueue.length === 0) return;
 
-  const revealed = [];
-  const remaining = [];
-
+  let newlyRevealed = 0;
   for (const rumour of game.rumourQueue) {
-    if (game.turn >= rumour.revealTurn) {
-      revealed.push(rumour);
-    } else {
-      remaining.push(rumour);
+    if (!rumour.revealed && game.turn >= rumour.revealTurn) {
+      rumour.revealed = true;
+      newlyRevealed++;
+      addEvent(rumour.text, rumour.type || 'diplomacy');
     }
   }
 
-  game.rumourQueue = remaining;
-
-  for (const rumour of revealed) {
-    addEvent(rumour.text, rumour.type || 'diplomacy');
-  }
-
-  if (revealed.length > 0) {
-    showToast('Rumours & Whispers', `${revealed.length} new rumour${revealed.length > 1 ? 's' : ''} heard`, 4000);
+  if (newlyRevealed > 0) {
+    showToast('Rumours & Whispers', `${newlyRevealed} new rumour${newlyRevealed > 1 ? 's' : ''} heard`, 4000);
   }
 }
 

--- a/src/intelligence.js
+++ b/src/intelligence.js
@@ -368,17 +368,8 @@ function renderRelationsMap() {
 function renderRumoursTab() {
   let html = '';
   const rumours = game.rumourQueue || [];
-  const revealed = rumours.filter(r => r.revealTurn < game.turn);
-  const pending = rumours.filter(r => r.revealTurn >= game.turn);
-
-  if (revealed.length > 0) {
-    html += `<div style="${S.card}">`;
-    html += '<div style="font-weight:bold;color:#ffd700;margin-bottom:4px;">\uD83D\uDCAC Confirmed Reports</div>';
-    for (const r of [...revealed].reverse().slice(0, 12)) {
-      html += `<div style="padding:3px 0;font-size:12px;border-bottom:1px solid rgba(255,255,255,0.03);"><span style="color:#888;">Turn ${r.revealTurn}:</span> ${r.text||r.summary||'Unknown event'}</div>`;
-    }
-    html += '</div>';
-  }
+  const revealed = rumours.filter(r => r.revealed || r.revealTurn < game.turn);
+  const pending = rumours.filter(r => !r.revealed && r.revealTurn >= game.turn);
 
   if (pending.length > 0) {
     html += `<div style="${S.card}">`;
@@ -386,6 +377,20 @@ function renderRumoursTab() {
     html += `<div style="color:#666;font-size:11px;margin-bottom:4px;">Your envoys investigate ${pending.length} rumour${pending.length>1?'s':''}...</div>`;
     for (const r of pending) {
       html += `<div style="padding:3px 0;font-size:12px;color:#888;font-style:italic;">${r.vagueSummary||'Something stirs in distant lands...'}</div>`;
+    }
+    html += '</div>';
+  }
+
+  if (revealed.length > 0) {
+    html += `<div style="${S.card}">`;
+    html += `<div style="font-weight:bold;color:#ffd700;margin-bottom:4px;">\uD83D\uDCAC All Reports (${revealed.length})</div>`;
+    for (const r of [...revealed].reverse()) {
+      const icon = r.text && r.text.includes('Paid informant') ? '\uD83D\uDCB0' :
+                   r.text && r.text.includes('Corroborated') ? '\uD83E\uDD1D' : '\uD83D\uDCAC';
+      html += `<div style="padding:4px 0;font-size:12px;border-bottom:1px solid rgba(255,255,255,0.03);">`;
+      html += `<span style="color:#666;font-size:10px;">Turn ${r.revealTurn || r.turn || '?'}</span> `;
+      html += `<span>${icon} ${r.text||r.summary||'Unknown event'}</span>`;
+      html += `</div>`;
     }
     html += '</div>';
   }


### PR DESCRIPTION
Rumours tab now shows full history. AI diplomacy rumours stay in queue instead of being deleted on reveal. Paid informant and corroborated rumours get distinct icons.\n\nhttps://claude.ai/code/session_01HBQaWuNQnWwa8JzxP3qMaL