### PR TITLE
chore: bump conviction auto jobs to every 2 hours

### DIFF
--- a/.github/workflows/conviction-autofix.yml
+++ b/.github/workflows/conviction-autofix.yml
@@ -2,8 +2,8 @@ name: Conviction Autofix
 
 on:
   schedule:
-    # Twice daily: 10am and 10pm UTC (2 hours after triage creates/updates issues)
-    - cron: '0 10,22 * * *'
+    # Every 2 hours (odd hours UTC, 1h after triage)
+    - cron: '0 1,3,5,7,9,11,13,15,17,19,21,23 * * *'
   workflow_dispatch: # manual trigger
 
 concurrency:

--- a/.github/workflows/conviction-close.yml
+++ b/.github/workflows/conviction-close.yml
@@ -2,8 +2,8 @@ name: Conviction Close
 
 on:
   schedule:
-    # Daily at 6am UTC (offset from triage at 8am/8pm)
-    - cron: '0 6 * * *'
+    # Every 2 hours (even hours UTC, same as triage)
+    - cron: '0 0,2,4,6,8,10,12,14,16,18,20,22 * * *'
   workflow_dispatch:
     inputs:
       dry_run:

--- a/.github/workflows/conviction-triage.yml
+++ b/.github/workflows/conviction-triage.yml
@@ -2,8 +2,8 @@ name: Conviction Triage
 
 on:
   schedule:
-    # Twice daily: 8am and 8pm UTC
-    - cron: '0 8,20 * * *'
+    # Every 2 hours (even hours UTC)
+    - cron: '0 0,2,4,6,8,10,12,14,16,18,20,22 * * *'
   workflow_dispatch: # manual trigger
 
 jobs:


### PR DESCRIPTION
## Summary
- Triage: every 2h on even hours UTC
- Autofix: every 2h on odd hours UTC (1h offset after triage)
- Close: every 2h on even hours UTC