### PR TITLE
feat: upgrade AI-to-AI diplomacy with motivation memory, spatial awar…

### DIFF
--- a/src/ai-diplomacy.js
+++ b/src/ai-diplomacy.js
@@ -8,6 +8,7 @@
 import { FACTIONS, FACTION_TRAITS } from './constants.js';
 import { game } from './state.js';
 import { addEvent, logAction, showToast } from './events.js';
+import { hexDistance } from './hex.js';
 
 // ============================================
 // VISIBILITY LEVELS
@@ -29,15 +30,27 @@ export function initAIRelations() {
   if (!game.aiAlliances) game.aiAlliances = [];
   if (!game.aiTradeDeals) game.aiTradeDeals = [];
   if (!game.aiDenouncements) game.aiDenouncements = [];
+  if (!game.aiMotivations) game.aiMotivations = {};
 
   const factionIds = Object.keys(FACTIONS);
-  for (const a of factionIds) {
+  // Include player as a first-class participant
+  const allParticipants = [...factionIds, 'player'];
+
+  for (const a of allParticipants) {
     if (!game.aiRelations[a]) game.aiRelations[a] = {};
-    for (const b of factionIds) {
+    if (!game.aiMotivations[a]) game.aiMotivations[a] = {};
+    for (const b of allParticipants) {
       if (a === b) continue;
       if (game.aiRelations[a][b] === undefined) {
         // Initial relations based on archetype compatibility
-        game.aiRelations[a][b] = getInitialRelation(a, b);
+        if (a === 'player' || b === 'player') {
+          game.aiRelations[a][b] = 0; // Start neutral with player
+        } else {
+          game.aiRelations[a][b] = getInitialRelation(a, b);
+        }
+      }
+      if (!game.aiMotivations[a][b]) {
+        game.aiMotivations[a][b] = [];
       }
     }
   }
@@ -72,7 +85,15 @@ export function processAIDiplomacy() {
   // 3. Natural relation drift
   applyRelationDrift(factionIds);
 
-  // 4. Each AI evaluates and may act toward each other AI
+  // 4. Spatial awareness — border tension (every 5 turns to avoid performance issues)
+  if (game.turn % 5 === 0) {
+    computeBorderTension(factionIds);
+  }
+
+  // 5. Balance of power — threat assessment
+  computePowerBalance(factionIds);
+
+  // 6. Each AI evaluates and may act toward each other AI (SKIP player as actor)
   for (const a of factionIds) {
     const traitsA = FACTION_TRAITS[a];
     if (!traitsA) continue;
@@ -100,10 +121,13 @@ export function processAIDiplomacy() {
     }
   }
 
-  // 5. Check if any secret pacts should activate
+  // 7. Player involvement — alliance/trade spillover
+  processPlayerSpillover(factionIds);
+
+  // 8. Check if any secret pacts should activate
   checkSecretPactActivation();
 
-  // 6. Process rumour queue — reveal pending rumours
+  // 9. Process rumour queue — reveal pending rumours
   processRumourQueue();
 }
 
@@ -156,7 +180,7 @@ function declareWar(a, b) {
   });
 
   // Relationship plummets
-  modifyRelation(a, b, -30);
+  modifyRelation(a, b, -30, { type: 'war_declared', detail: factionB.name });
 
   markActed(a, b);
   markActed(b, a);
@@ -187,8 +211,8 @@ function tryDenounce(a, b, relation, traitsA) {
 
   // Record denouncement
   game.aiDenouncements.push({ from: a, to: b, turn: game.turn });
-  modifyRelation(a, b, -5);
-  modifyRelation(b, a, -5);
+  modifyRelation(a, b, -5, { type: 'denouncement', detail: FACTIONS[b]?.name });
+  modifyRelation(b, a, -5, { type: 'denounced_by', detail: FACTIONS[a]?.name });
   markActed(a, b);
 
   // PUBLIC — immediate event
@@ -223,8 +247,8 @@ function tryProposeAlliance(a, b, relation, traitsA) {
 
   // Alliance formed
   game.aiAlliances.push({ factions: [a, b], turn: game.turn });
-  modifyRelation(a, b, 15);
-  modifyRelation(b, a, 15);
+  modifyRelation(a, b, 15, { type: 'alliance_formed', detail: FACTIONS[b]?.name });
+  modifyRelation(b, a, 15, { type: 'alliance_formed', detail: FACTIONS[a]?.name });
   markActed(a, b);
 
   const factionA = FACTIONS[a];
@@ -235,11 +259,13 @@ function tryProposeAlliance(a, b, relation, traitsA) {
     text: `Whispers suggest ${factionA.name} and ${factionB.name} are growing closer`,
     revealTurn: game.turn + 1,
     type: 'diplomacy',
+    relatedFactions: [a, b],
   });
   game.rumourQueue.push({
     text: `${factionA.name} and ${factionB.name} have formalised an alliance`,
     revealTurn: game.turn + 2 + Math.floor(Math.random() * 2), // 2-3 turns
     type: 'diplomacy',
+    relatedFactions: [a, b],
   });
 
   logAction('diplomacy', `${factionA.name} and ${factionB.name} form alliance`, {
@@ -272,8 +298,8 @@ function tryProposeTrade(a, b, relation, traitsA, statsA) {
     turn: game.turn,
     goldPerTurn: goldExchange,
   });
-  modifyRelation(a, b, 5);
-  modifyRelation(b, a, 5);
+  modifyRelation(a, b, 5, { type: 'trade_established', detail: FACTIONS[b]?.name });
+  modifyRelation(b, a, 5, { type: 'trade_established', detail: FACTIONS[a]?.name });
   markActed(a, b);
 
   const factionA = FACTIONS[a];
@@ -284,6 +310,7 @@ function tryProposeTrade(a, b, relation, traitsA, statsA) {
     text: `Rumour: Merchants have been seen travelling between ${factionA.name} and ${factionB.name}'s lands`,
     revealTurn: game.turn + 1 + Math.floor(Math.random() * 2),
     type: 'diplomacy',
+    relatedFactions: [a, b],
   });
 
   logAction('diplomacy', `${factionA.name} and ${factionB.name} establish trade (+${goldExchange}g/turn)`, {
@@ -457,8 +484,8 @@ function checkWarEndings() {
     logAction('diplomacy', msg, { type: 'ai_peace', factions: [war.attacker, war.defender] });
 
     // Small relation boost from peace
-    modifyRelation(war.attacker, war.defender, 5);
-    modifyRelation(war.defender, war.attacker, 5);
+    modifyRelation(war.attacker, war.defender, 5, { type: 'peace_restored', detail: reason });
+    modifyRelation(war.defender, war.attacker, 5, { type: 'peace_restored', detail: reason });
   }
 }
 
@@ -474,25 +501,25 @@ function applyRelationDrift(factionIds) {
       if (!areAtWar(a, b)) {
         const rel = game.aiRelations[a][b] || 0;
         if (rel < 0) {
-          modifyRelation(a, b, 2);
-          modifyRelation(b, a, 2);
+          modifyRelation(a, b, 2, { type: 'relation_drift', detail: 'time heals' });
+          modifyRelation(b, a, 2, { type: 'relation_drift', detail: 'time heals' });
         }
       } else {
         // At war: relations deteriorate
-        modifyRelation(a, b, -2);
-        modifyRelation(b, a, -2);
+        modifyRelation(a, b, -2, { type: 'war_attrition', detail: 'ongoing conflict' });
+        modifyRelation(b, a, -2, { type: 'war_attrition', detail: 'ongoing conflict' });
       }
 
       // Alliances improve relations slowly
       if (hasAlliance(a, b)) {
-        modifyRelation(a, b, 1);
-        modifyRelation(b, a, 1);
+        modifyRelation(a, b, 1, { type: 'alliance_maintenance', detail: 'shared interests' });
+        modifyRelation(b, a, 1, { type: 'alliance_maintenance', detail: 'shared interests' });
       }
 
       // Trade deals improve relations slowly
       if (hasTradeDeal(a, b)) {
-        modifyRelation(a, b, 1);
-        modifyRelation(b, a, 1);
+        modifyRelation(a, b, 1, { type: 'trade_maintenance', detail: 'mutual benefit' });
+        modifyRelation(b, a, 1, { type: 'trade_maintenance', detail: 'mutual benefit' });
       }
     }
   }
@@ -509,7 +536,21 @@ function processRumourQueue() {
     if (!rumour.revealed && game.turn >= rumour.revealTurn) {
       rumour.revealed = true;
       newlyRevealed++;
-      addEvent(rumour.text, rumour.type || 'diplomacy');
+
+      // Enhance rumour text with motivation details if available
+      let enhancedText = rumour.text;
+      if (rumour.relatedFactions && rumour.relatedFactions.length >= 2) {
+        const [a, b] = rumour.relatedFactions;
+        const motivations = getRelationMotivations(a, b);
+        if (motivations.length > 0) {
+          const recent = motivations[motivations.length - 1];
+          if (recent.detail) {
+            enhancedText = `${rumour.text} — ${recent.detail}`;
+          }
+        }
+      }
+
+      addEvent(enhancedText, rumour.type || 'diplomacy');
     }
   }
 
@@ -521,10 +562,35 @@ function processRumourQueue() {
 // ============================================
 // HELPER FUNCTIONS
 // ============================================
-function modifyRelation(a, b, delta) {
+function modifyRelation(a, b, delta, motivation = null) {
   if (!game.aiRelations[a]) game.aiRelations[a] = {};
   const current = game.aiRelations[a][b] || 0;
   game.aiRelations[a][b] = Math.max(-100, Math.min(100, current + delta));
+
+  // Log motivation if provided
+  if (motivation && motivation.type !== 'relation_drift') {
+    // Skip relation_drift unless delta >= 2 to avoid noise
+    if (motivation.type === 'relation_drift' && Math.abs(delta) < 2) {
+      return;
+    }
+
+    if (!game.aiMotivations[a]) game.aiMotivations[a] = {};
+    if (!game.aiMotivations[a][b]) game.aiMotivations[a][b] = [];
+
+    const entry = {
+      type: motivation.type,
+      delta: delta,
+      turn: game.turn,
+      detail: motivation.detail || null,
+    };
+
+    game.aiMotivations[a][b].push(entry);
+
+    // Keep max 10 entries per pair (FIFO)
+    if (game.aiMotivations[a][b].length > 10) {
+      game.aiMotivations[a][b].shift();
+    }
+  }
 }
 
 function areAtWar(a, b) {
@@ -568,6 +634,216 @@ export function processAITradeIncome() {
       const stats = game.factionStats[fid];
       if (stats) {
         stats.gold = (stats.gold || 0) + (deal.goldPerTurn || 0);
+      }
+    }
+  }
+}
+
+// ============================================
+// FEATURE 1: MOTIVATION MEMORY
+// ============================================
+export function getRelationMotivations(a, b) {
+  return (game.aiMotivations?.[a]?.[b] || []).slice(); // Return a copy
+}
+
+export function getRelationSummary(a, b) {
+  const motivations = getRelationMotivations(a, b);
+  if (motivations.length === 0) return 'Neutral stance';
+
+  const relation = game.aiRelations?.[a]?.[b] || 0;
+  let stance = 'Neutral';
+  if (relation > 30) stance = 'Friendly';
+  else if (relation > 10) stance = 'Cordial';
+  else if (relation < -30) stance = 'Hostile';
+  else if (relation < -10) stance = 'Tense';
+
+  // Get top 3 most recent motivations
+  const recent = motivations.slice(-3).reverse();
+  const reasons = recent.map(m => {
+    if (m.detail) return `${m.type} (${m.detail})`;
+    return m.type;
+  });
+
+  return `${stance}: ${reasons.join(', ')}`;
+}
+
+// ============================================
+// FEATURE 2: SPATIAL AWARENESS
+// ============================================
+function computeBorderTension(factionIds) {
+  // Include player for tension computation
+  const allFactions = [...factionIds, 'player'];
+
+  for (let i = 0; i < allFactions.length; i++) {
+    for (let j = i + 1; j < allFactions.length; j++) {
+      const a = allFactions[i];
+      const b = allFactions[j];
+
+      // Find minimum distance between any city pair
+      const citiesA = getCitiesForFaction(a);
+      const citiesB = getCitiesForFaction(b);
+
+      let minDistance = Infinity;
+      for (const ca of citiesA) {
+        for (const cb of citiesB) {
+          const dist = hexDistance(ca.col, ca.row, cb.col, cb.row);
+          minDistance = Math.min(minDistance, dist);
+        }
+      }
+
+      // Apply relation modifiers based on proximity
+      if (minDistance <= 8) {
+        // Close neighbors: border tension
+        const tension = -5 + Math.floor((8 - minDistance) * 0.5); // -5 to -8
+        modifyRelation(a, b, tension, { type: 'border_tension', detail: `${minDistance} hexes apart` });
+        modifyRelation(b, a, tension, { type: 'border_tension', detail: `${minDistance} hexes apart` });
+      } else if (minDistance > 20) {
+        // Far apart: non-threatening, small positive modifier
+        modifyRelation(a, b, 1, { type: 'distant_peace', detail: 'far enough apart' });
+        modifyRelation(b, a, 1, { type: 'distant_peace', detail: 'far enough apart' });
+      }
+    }
+  }
+}
+
+function getCitiesForFaction(fid) {
+  const cities = [];
+  if (fid === 'player') {
+    // Player's cities
+    if (game.cities) {
+      for (const city of game.cities) {
+        cities.push({ col: city.col, row: city.row });
+      }
+    }
+  } else {
+    // AI faction capital
+    if (game.factionCities[fid]) {
+      cities.push(game.factionCities[fid]);
+    }
+    // AI expansion cities
+    if (game.aiFactionCities[fid]) {
+      for (const city of game.aiFactionCities[fid]) {
+        cities.push(city);
+      }
+    }
+  }
+  return cities;
+}
+
+// ============================================
+// FEATURE 3: BALANCE OF POWER
+// ============================================
+function computePowerBalance(factionIds) {
+  // Calculate threat score for each faction
+  const threatScores = {};
+  for (const fid of factionIds) {
+    const stats = game.factionStats[fid];
+    if (!stats) {
+      threatScores[fid] = 0;
+      continue;
+    }
+    threatScores[fid] = (stats.military || 0) * 0.4 +
+                        (stats.territory || 0) * 0.3 +
+                        (stats.gold || 0) * 0.002 +
+                        (stats.score || 0) * 0.3;
+  }
+
+  // Find leader and average
+  const scores = Object.values(threatScores);
+  if (scores.length === 0) return;
+
+  const avgThreat = scores.reduce((a, b) => a + b, 0) / scores.length;
+  let maxThreat = 0;
+  let leader = null;
+  let minThreat = Infinity;
+  let underdog = null;
+
+  for (const fid of factionIds) {
+    if (threatScores[fid] > maxThreat) {
+      maxThreat = threatScores[fid];
+      leader = fid;
+    }
+    if (threatScores[fid] < minThreat) {
+      minThreat = threatScores[fid];
+      underdog = fid;
+    }
+  }
+
+  // Apply coalition-against-leader dynamic
+  if (leader && maxThreat > avgThreat * 1.5) {
+    // Leader is ahead: others resent them
+    for (const fid of factionIds) {
+      if (fid === leader) continue;
+      const penalty = -3 - Math.floor((maxThreat - avgThreat) * 0.005); // -3 to -8
+      modifyRelation(fid, leader, penalty, { type: 'power_threat', detail: 'dominance concern' });
+    }
+  }
+
+  // Apply underdog sympathy
+  if (underdog && minThreat < avgThreat * 0.6) {
+    for (const fid of factionIds) {
+      if (fid === underdog) continue;
+      modifyRelation(fid, underdog, 2, { type: 'underdog_sympathy', detail: 'weaker faction' });
+    }
+  }
+}
+
+// ============================================
+// FEATURE 4: PLAYER INVOLVEMENT
+// ============================================
+function processPlayerSpillover(factionIds) {
+  // Check player's trade routes
+  const playerTrades = new Set();
+  if (game.tradeRoutes) {
+    for (const route of game.tradeRoutes) {
+      if (route.factionId) {
+        playerTrades.add(route.factionId);
+      }
+    }
+  }
+
+  // Check player's alliances
+  const playerAllies = new Set();
+  if (game.aiAlliances) {
+    for (const alliance of game.aiAlliances) {
+      if (alliance.factions.includes('player')) {
+        for (const fid of alliance.factions) {
+          if (fid !== 'player') {
+            playerAllies.add(fid);
+          }
+        }
+      }
+    }
+  }
+
+  // For each AI faction, apply spillover effects
+  for (const fid of factionIds) {
+    // If AI is allied/trading with player, consider it a positive factor
+    if (playerAllies.has(fid) || playerTrades.has(fid)) {
+      // AI's enemies should sour toward the player
+      for (const other of factionIds) {
+        if (other === fid) continue;
+        const relation = game.aiRelations[fid][other] || 0;
+        if (relation < -20) {
+          // fid is enemy with other, so other should sour toward player
+          modifyRelation(other, 'player', -2, { type: 'alliance_spillover', detail: `allied with ${FACTIONS[fid]?.name}` });
+        }
+      }
+    }
+
+    // Check if AI has enemies of the player
+    const playerRelation = game.aiRelations[fid]['player'] || 0;
+    if (playerRelation < -20 && game.aiAlliances) {
+      // This faction is hostile to player; their allies should respect that
+      for (const alliance of game.aiAlliances) {
+        if (alliance.factions.includes(fid)) {
+          for (const allyId of alliance.factions) {
+            if (allyId !== fid && allyId !== 'player') {
+              // Ally of enemy should sour slightly toward player
+              modifyRelation(allyId, 'player', -1, { type: 'spillover_tension', detail: `ally of hostile faction` });
+            }
+          }
+        }
       }
     }
   }

--- a/src/main.js
+++ b/src/main.js
@@ -38,7 +38,7 @@ import { generateMap, getTileYields, getTileName, getTileMoveCost, isTilePassabl
 import { hexToPixel, pixelToHex, drawHex, getHexNeighbors, hexDistance, createFogOfWar } from './hex.js';
 import { MAP_COLS, MAP_ROWS, BASE_TERRAIN } from './constants.js';
 import { drawDetailedHex } from './terrain-render.js';
-import { processAIDiplomacy, resetTurnActions, getAIRelation, getAIWars, getAIAlliances, getAISecretPacts, getAITradeDeals } from './ai-diplomacy.js';
+import { processAIDiplomacy, resetTurnActions, getAIRelation, getAIWars, getAIAlliances, getAISecretPacts, getAITradeDeals, getRelationMotivations, getRelationSummary } from './ai-diplomacy.js';
 import { initTutorial, tutorialNext, tutorialPrev, closeTutorial } from './tutorial.js';
 import { renderDiplomacyWithIntel, switchDiploTab, getIntelSummary } from './intelligence.js';
 import { renderAdvisorPanel, openAdvisor, sendAdvisorMessage, closeAdvisorChat, isAdvisorChatActive } from './diplomacy-api.js';
@@ -107,6 +107,8 @@ window.getAIWars = getAIWars;
 window.getAIAlliances = getAIAlliances;
 window.getAISecretPacts = getAISecretPacts;
 window.getAITradeDeals = getAITradeDeals;
+window.getRelationMotivations = getRelationMotivations;
+window.getRelationSummary = getRelationSummary;
 window.showGiftUnitPanel = showGiftUnitPanel;
 window.giftUnit = giftUnit;
 window.discoverVillage = discoverVillage;

--- a/src/save-load.js
+++ b/src/save-load.js
@@ -87,6 +87,7 @@ function migrateTiles(state) {
   if (!state.aiAlliances) state.aiAlliances = [];
   if (!state.aiTradeDeals) state.aiTradeDeals = [];
   if (!state.aiDenouncements) state.aiDenouncements = [];
+  if (!state.aiMotivations) state.aiMotivations = {};
   if (!state.rumourQueue) state.rumourQueue = [];
   // Ensure every tile has col/row (missing in saves before v4)
   if (state.map) {


### PR DESCRIPTION
…eness, balance of power, and player involvement

Four interconnected systems that make AI diplomacy feel alive:

1. Motivation Memory — relation changes now log typed events (war_declared, border_tension, etc.) with max 10 per pair. Factions remember WHY they feel the way they do, and rumours surface the reasons.

2. Spatial Awareness — every 5 turns, computes city proximity between all faction pairs. Close neighbors (≤8 hexes) get border tension penalties; distant factions get a small peace bonus.

3. Balance of Power — threat scoring (military, territory, gold, score) drives coalition dynamics. The leading faction gets resented (-3 to -8), the underdog gets sympathy (+2).

4. Player Involvement — player wired into aiRelations as first-class participant. AI feelings toward the player shift based on border tension, power balance, and alliance/trade spillover (your friends' enemies become your enemies).