### PR TITLE
Configure allowed_bots parameter in Claude code review workflows

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -94,6 +94,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: "claude"
           prompt: |
             You are reviewing PR #${{ steps.pr.outputs.number }} in the Uncivilised game repo.
             Base branch: ${{ steps.pr.outputs.base }}
@@ -172,6 +173,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          allowed_bots: "claude"
           prompt: |
             You are reviewing PR #${{ steps.pr.outputs.number }} in the Uncivilised game repo.
             Base branch: ${{ steps.pr.outputs.base }}


### PR DESCRIPTION
## Summary
Added the `allowed_bots` parameter to both Claude code review workflow steps to explicitly restrict code reviews to the "claude" bot.

## Changes
- Added `allowed_bots: "claude"` parameter to the first `anthropics/claude-code-action@v1` step (OAuth token authentication)
- Added `allowed_bots: "claude"` parameter to the second `anthropics/claude-code-action@v1` step (API key authentication)

## Details
This change ensures that only the "claude" bot is authorized to perform code reviews in the PR review workflow. This provides explicit bot authorization control and prevents unintended bots from executing the code review action.

https://claude.ai/code/session_01Y9FKxrF2MbwawXNCmBD5MY