### PR TITLE
fix: allow issue_comment-triggered workflow_run in automerge

### DIFF
--- a/.github/workflows/conviction-automerge.yml
+++ b/.github/workflows/conviction-automerge.yml
@@ -27,7 +27,7 @@ jobs:
        github.event.check_suite.conclusion == 'success') ||
       (github.event_name == 'workflow_run' &&
        github.event.workflow_run.conclusion == 'success' &&
-       github.event.workflow_run.event == 'pull_request')
+       contains(fromJSON('["pull_request","issue_comment"]'), github.event.workflow_run.event))
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Summary
- The `/review` command triggers via `issue_comment`, not `pull_request`
- PR #316 restricted `workflow_run` to only `pull_request` events, which inadvertently blocked automerge from firing after `/review`-triggered reviews
- Add `issue_comment` to the allowed event list

Found while simulating the pipeline on PR #314 — the review fallback worked correctly but automerge never fired because the workflow_run event was filtered out.

## Test plan
- [ ] Trigger `/review` on a conviction PR and verify automerge fires