### PR TITLE
Fix enemy stacking after civilian capture, merge territory borders

### DIFF
--- a/src/combat.js
+++ b/src/combat.js
@@ -27,9 +27,20 @@ function resolveCombat(attacker, defender) {
     defender.owner = attacker.owner;
     defender.moveLeft = 0;
     // Only melee units move onto the captured unit's tile (ranged stay put)
+    // But don't move if an enemy military unit already occupies that tile
     if (aType.rangedCombat <= 0 || aType.range <= 0) {
-      attacker.col = defender.col;
-      attacker.row = defender.row;
+      const occupants = game.units.filter(u =>
+        u.col === defender.col && u.row === defender.row &&
+        u.id !== attacker.id && u.id !== defender.id
+      );
+      const enemyMilitary = occupants.some(u => {
+        const ut = UNIT_TYPES[u.type];
+        return u.owner !== attacker.owner && ut && ut.class !== 'civilian';
+      });
+      if (!enemyMilitary) {
+        attacker.col = defender.col;
+        attacker.row = defender.row;
+      }
     }
     const ownerName = FACTIONS[prevOwner]?.name || prevOwner;
     const captorName = FACTIONS[attacker.owner]?.name || attacker.owner;

--- a/src/render.js
+++ b/src/render.js
@@ -454,59 +454,64 @@ function render() {
         ctx.textBaseline = 'alphabetic';
       }
 
-      // City territory with cultural borders
-      for (const city of game.cities) {
-        const bRadius = city.borderRadius || 2;
-        const dist = hexDistance(c, r, city.col, city.row);
-        if (dist <= bRadius) {
-          // Subtle territory fill
+      // City territory with cultural borders (merged across all player cities)
+      {
+        const inPlayerTerritory = game.cities.some(city =>
+          hexDistance(c, r, city.col, city.row) <= (city.borderRadius || 2)
+        );
+        if (inPlayerTerritory) {
           drawHex(ctx, sx, sy, HEX_SIZE - 1);
           ctx.fillStyle = 'rgba(201,168,76,0.06)';
           ctx.fill();
-          // Draw border edge on outermost ring
-          if (dist === bRadius) {
-            const nbs = getHexNeighbors(c, r);
-            for (const nb of nbs) {
-              if (hexDistance(nb.col, nb.row, city.col, city.row) > bRadius) {
-                // This edge faces outside territory — draw border segment
-                const nbPos = hexToPixel(nb.col, nb.row);
-                const edx = (nbPos.x - (sx + camX)) * 0.48;
-                const edy = (nbPos.y - (sy + camY)) * 0.48;
-                ctx.strokeStyle = 'rgba(201,168,76,0.6)';
-                ctx.lineWidth = 2.5;
-                ctx.beginPath();
-                ctx.moveTo(sx + edx - edy * 0.5, sy + edy + edx * 0.5);
-                ctx.lineTo(sx + edx + edy * 0.5, sy + edy - edx * 0.5);
-                ctx.stroke();
-              }
+          // Only draw border edge if the neighbor is outside ALL player cities
+          const nbs = getHexNeighbors(c, r);
+          for (const nb of nbs) {
+            const nbInPlayerTerritory = game.cities.some(city =>
+              hexDistance(nb.col, nb.row, city.col, city.row) <= (city.borderRadius || 2)
+            );
+            if (!nbInPlayerTerritory) {
+              const nbPos = hexToPixel(nb.col, nb.row);
+              const edx = (nbPos.x - (sx + camX)) * 0.48;
+              const edy = (nbPos.y - (sy + camY)) * 0.48;
+              ctx.strokeStyle = 'rgba(201,168,76,0.6)';
+              ctx.lineWidth = 2.5;
+              ctx.beginPath();
+              ctx.moveTo(sx + edx - edy * 0.5, sy + edy + edx * 0.5);
+              ctx.lineTo(sx + edx + edy * 0.5, sy + edy - edx * 0.5);
+              ctx.stroke();
             }
           }
         }
       }
 
-      // Faction territory with borders
+      // Faction territory with borders (merged across capital + expansion cities per faction)
       for (const [fid, fc] of Object.entries(game.factionCities)) {
         if (!fc.color) continue;
-        const bRadius = fc.borderRadius || 2;
-        const dist = hexDistance(c, r, fc.col, fc.row);
-        if (dist <= bRadius) {
+        // Collect all cities for this faction (capital + expansions)
+        const allFactionCities = [fc, ...(game.aiFactionCities?.[fid] || [])];
+        const inFactionTerritory = allFactionCities.some(city =>
+          hexDistance(c, r, city.col, city.row) <= (city.borderRadius || 2)
+        );
+        if (inFactionTerritory) {
           drawHex(ctx, sx, sy, HEX_SIZE - 1);
           ctx.fillStyle = hexToRgba(fc.color, 0.05);
           ctx.fill();
-          if (dist === bRadius) {
-            const nbs = getHexNeighbors(c, r);
-            for (const nb of nbs) {
-              if (hexDistance(nb.col, nb.row, fc.col, fc.row) > bRadius) {
-                const nbPos = hexToPixel(nb.col, nb.row);
-                const edx = (nbPos.x - (sx + camX)) * 0.48;
-                const edy = (nbPos.y - (sy + camY)) * 0.48;
-                ctx.strokeStyle = hexToRgba(fc.color, 0.6);
-                ctx.lineWidth = 2.5;
-                ctx.beginPath();
-                ctx.moveTo(sx + edx - edy * 0.5, sy + edy + edx * 0.5);
-                ctx.lineTo(sx + edx + edy * 0.5, sy + edy - edx * 0.5);
-                ctx.stroke();
-              }
+          // Only draw border edge if neighbor is outside ALL of this faction's cities
+          const nbs = getHexNeighbors(c, r);
+          for (const nb of nbs) {
+            const nbInFactionTerritory = allFactionCities.some(city =>
+              hexDistance(nb.col, nb.row, city.col, city.row) <= (city.borderRadius || 2)
+            );
+            if (!nbInFactionTerritory) {
+              const nbPos = hexToPixel(nb.col, nb.row);
+              const edx = (nbPos.x - (sx + camX)) * 0.48;
+              const edy = (nbPos.y - (sy + camY)) * 0.48;
+              ctx.strokeStyle = hexToRgba(fc.color, 0.6);
+              ctx.lineWidth = 2.5;
+              ctx.beginPath();
+              ctx.moveTo(sx + edx - edy * 0.5, sy + edy + edx * 0.5);
+              ctx.lineTo(sx + edx + edy * 0.5, sy + edy - edx * 0.5);
+              ctx.stroke();
             }
           }
         }
@@ -643,9 +648,14 @@ function render() {
         if (game.visibleTiles && !(game.visibleTiles[aic.row] && game.visibleTiles[aic.row][aic.col])) continue;
         const ap = hexToPixel(aic.col, aic.row);
         const ax = ap.x - camX, ay = ap.y - camY;
-        // Territory
+        // Territory (merged with same faction's other cities — borders handled in faction pass above)
         const br = aic.borderRadius || 1;
         const aColor = aic.color || '#888';
+        // Collect all cities for this faction
+        const allFidCities = [
+          ...(game.factionCities?.[fid] ? [game.factionCities[fid]] : []),
+          ...(game.aiFactionCities?.[fid] || []),
+        ];
         for (let dr = -br; dr <= br; dr++) {
           for (let dc = -br; dc <= br; dc++) {
             const nr = aic.row + dr, nc = ((aic.col + dc) % MAP_COLS + MAP_COLS) % MAP_COLS;
@@ -654,11 +664,14 @@ function render() {
             const bx = bp.x - camX, by = bp.y - camY;
             ctx.fillStyle = hexToRgba(aColor, 0.05);
             drawHex(ctx, bx, by, HEX_SIZE - 1); ctx.fill();
-            // Border edge segments
+            // Border edge segments — only if neighbor is outside ALL faction cities
             if (hexDistance(nc, nr, aic.col, aic.row) === br) {
               const nbs = getHexNeighbors(nc, nr);
               for (const nb of nbs) {
-                if (hexDistance(nb.col, nb.row, aic.col, aic.row) > br) {
+                const nbInFaction = allFidCities.some(city =>
+                  hexDistance(nb.col, nb.row, city.col, city.row) <= (city.borderRadius || 2)
+                );
+                if (!nbInFaction) {
                   const nbPos = hexToPixel(nb.col, nb.row);
                   const edx = (nbPos.x - (bx + camX)) * 0.48;
                   const edy = (nbPos.y - (by + camY)) * 0.48;

--- a/tests/combat-resolve.test.js
+++ b/tests/combat-resolve.test.js
@@ -63,6 +63,33 @@ describe('resolveCombat()', () => {
     expect(defender.moveLeft).toBe(0);
   });
 
+  test('should not move attacker onto captured civilian tile if enemy military is there', () => {
+    // Barbarian attacks a settler that is stacked with a player warrior
+    const barbarian = makeUnit({ id: 1, col: 5, row: 5, type: 'warrior', owner: 'barbarian' });
+    const settler = makeUnit({ id: 2, col: 6, row: 5, type: 'settler', owner: 'player' });
+    const warrior = makeUnit({ id: 3, col: 6, row: 5, type: 'warrior', owner: 'player' });
+    state.units = [barbarian, settler, warrior];
+
+    const result = resolveCombat(barbarian, settler);
+    expect(result.captured).toBe(true);
+    expect(settler.owner).toBe('barbarian');
+    // Barbarian should NOT move onto the tile — player warrior is there
+    expect(barbarian.col).toBe(5);
+    expect(barbarian.row).toBe(5);
+  });
+
+  test('should move attacker onto captured civilian tile if no enemy military present', () => {
+    const barbarian = makeUnit({ id: 1, col: 5, row: 5, type: 'warrior', owner: 'barbarian' });
+    const settler = makeUnit({ id: 2, col: 6, row: 5, type: 'settler', owner: 'player' });
+    state.units = [barbarian, settler];
+
+    const result = resolveCombat(barbarian, settler);
+    expect(result.captured).toBe(true);
+    // Barbarian SHOULD move onto the tile — no enemy military present
+    expect(barbarian.col).toBe(6);
+    expect(barbarian.row).toBe(5);
+  });
+
   // ── Defender death ──
 
   test('should remove defender from game.units when killed', () => {


### PR DESCRIPTION
## Summary

- **Fix enemy stacking after civilian capture**: When a barbarian/AI captures a settler stacked with a player military unit, the attacker no longer moves onto the tile. Prevents two opposing military units from occupying the same hex.
- **Merge territory borders**: Adjacent cities of the same owner now show a single unified border outline instead of overlapping per-city circles. Applies to player cities, faction capitals, and expansion cities.

## Test plan

- [x] All 277 tests pass
- [ ] Stack a settler with a warrior, let barbarian capture settler — verify barbarian stays on its original tile
- [ ] Found two cities next to each other — verify a single merged border outline with no internal lines

https://claude.ai/code/session_01KnyFkgRNaNcGCpSoUK5hmL