### PR TITLE
City selection for production targeting with visual highlight

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -258,7 +258,7 @@ function createInitialState() {
     barbarianCamps: [],
     continentId: continentId, mainContinent: mainContinent,
     aiFactions: {}, aiFactionCities: {},
-    selectedUnitId: null,
+    selectedUnitId: null, selectedCityIdx: null,
     relationships: {
       emperor_valerian: 0, shadow_kael: -10, merchant_prince_castellan: 10,
       pirate_queen_elara: -20, commander_thane: 5, rebel_leader_sera: 0,

--- a/src/render.js
+++ b/src/render.js
@@ -946,6 +946,16 @@ function render() {
     const sx = pos.x - camX;
     const sy = pos.y - camY;
 
+    // Selected city highlight — pulsing glow ring
+    if (game.selectedCityIdx === ci) {
+      const pulse = 0.5 + 0.3 * Math.sin(performance.now() / 400);
+      ctx.beginPath();
+      ctx.arc(sx, sy, HEX_SIZE * 1.5, 0, Math.PI * 2);
+      ctx.strokeStyle = `rgba(201,168,76,${pulse})`;
+      ctx.lineWidth = 3;
+      ctx.stroke();
+    }
+
     // Faction ownership ring
     drawFactionRing(ctx, sx, sy, PLAYER_COLOR);
     // Settlement sprite (based on population)

--- a/src/ui-panels.js
+++ b/src/ui-panels.js
@@ -307,6 +307,12 @@ function showCityPanel(cityData) {
   const panel = document.getElementById('tile-info');
   const isPlayer = cityData.owner === 'player';
 
+  // Track selected city for production/purchase targeting
+  if (isPlayer) {
+    const idx = game.cities.findIndex(c => c.col === cityData.col && c.row === cityData.row);
+    game.selectedCityIdx = idx >= 0 ? idx : 0;
+  }
+
   let title, body;
   if (isPlayer) {
     title = `\u2605 ${cityData.name}`;
@@ -554,7 +560,11 @@ function switchProduction(startFn) {
 
 function getNearestCityIndex() {
   if (game.cities.length <= 1) return 0;
-  // Find city closest to camera center
+  // Use explicitly selected city if available
+  if (game.selectedCityIdx != null && game.selectedCityIdx < game.cities.length) {
+    return game.selectedCityIdx;
+  }
+  // Fallback: find city closest to camera center
   const camCenterCol = Math.floor((game.cameraX + (canvasW / 2) / gameZoom) / (HEX_SIZE * SQRT3));
   const camCenterRow = Math.floor((game.cameraY + (canvasH / 2) / gameZoom) / (HEX_SIZE * 1.5));
   let bestIdx = 0, bestDist = Infinity;


### PR DESCRIPTION
## Summary

- Clicking a player city sets `game.selectedCityIdx` — production and purchases target that city
- Units spawn at/near the selected city instead of guessing from camera position
- Selected city shows a pulsing gold ring highlight on the map
- 'c' key already centers on next movable unit (confirmed working, no change needed)

## Test plan

- [x] All 280 tests pass
- [ ] Click a city, open build panel, recruit a unit — verify it spawns at that city
- [ ] Verify pulsing gold ring appears around selected city

https://claude.ai/code/session_01KnyFkgRNaNcGCpSoUK5hmL