### PR TITLE
Add game briefing overlay for new players

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,6 +80,26 @@
     </footer>
   </div>
 
+  <!-- Game Briefing Overlay -->
+  <div id="game-briefing" class="briefing-overlay" style="display:none">
+    <div class="briefing-panel">
+      <div class="briefing-header">
+        <svg viewBox="0 0 32 32" class="briefing-icon" aria-hidden="true">
+          <circle cx="16" cy="16" r="14" fill="none" stroke="#c9a84c" stroke-width="1.5" opacity="0.6"/>
+          <path d="M16 6 L18 13 L25 13 L19.5 17.5 L21.5 25 L16 20.5 L10.5 25 L12.5 17.5 L7 13 L14 13 Z" fill="none" stroke="#c9a84c" stroke-width="1" opacity="0.8"/>
+        </svg>
+        <h2 class="briefing-title">The World Awaits</h2>
+      </div>
+      <div class="briefing-body">
+        <p>Scattered across the map are resources that will determine the fate of civilisations. <strong>Gold ore</strong> and <strong>luxury goods</strong> generate wealth and keep your people content. <strong>Iron</strong> and <strong>horses</strong> — hidden until you develop the right technologies — unlock military units that can shift the balance of power.</p>
+        <p>No single civilisation controls everything. Those who hold scarce resources become either valued allies or inevitable targets.</p>
+        <p>Use diplomacy skilfully: <strong>forge alliances</strong>, broker <strong>trade deals</strong>, negotiate <strong>secret pacts</strong>, or <strong>marry into dynasties</strong>. Every leader remembers what you say — and what you promise.</p>
+        <p class="briefing-warning">Expand carefully. Armies require gold to maintain. Cities without luxuries risk revolt. The civilisation that balances ambition with stability will endure.</p>
+      </div>
+      <button id="btn-briefing-begin" class="btn btn-primary briefing-btn">Begin</button>
+    </div>
+  </div>
+
   <!-- Signup Modal -->
   <div id="signup-modal" class="auth-modal-overlay" style="display:none">
     <div class="auth-modal">

--- a/src/main.js
+++ b/src/main.js
@@ -344,6 +344,23 @@ async function startNewGame() {
     }
   }
 
+  showGameBriefing(playerName);
+}
+
+function showGameBriefing(playerName) {
+  const briefing = document.getElementById('game-briefing');
+  if (!briefing) { launchGame(playerName); return; }
+  briefing.style.display = 'flex';
+  const btn = document.getElementById('btn-briefing-begin');
+  const fresh = btn.cloneNode(true);
+  btn.parentNode.replaceChild(fresh, btn);
+  fresh.addEventListener('click', () => {
+    briefing.style.display = 'none';
+    launchGame(playerName);
+  });
+}
+
+async function launchGame(playerName) {
   setNextUnitId(1);
   setGame(createInitialState());
 
@@ -393,6 +410,7 @@ async function startNewGame() {
   }
   if (playerName) await registerActiveGame(playerName);
   await autoSave();
+}
 }
 
 async function continueGame() {

--- a/src/main.js
+++ b/src/main.js
@@ -411,7 +411,6 @@ async function launchGame(playerName) {
   if (playerName) await registerActiveGame(playerName);
   await autoSave();
 }
-}
 
 async function continueGame() {
   const playerName = safeStorage.getItem('uncivilised_username');

--- a/style.css
+++ b/style.css
@@ -401,6 +401,70 @@ a:hover { text-decoration: underline; }
   text-align: center;
 }
 
+/* ---- Game Briefing Overlay ---- */
+.briefing-overlay {
+  position: fixed;
+  top: 0; left: 0; right: 0; bottom: 0;
+  background: rgba(0,0,0,0.85);
+  z-index: 10000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  animation: fadeIn 0.3s ease;
+}
+.briefing-panel {
+  background: linear-gradient(170deg, #1a1c1b 0%, #131613 100%);
+  border: 1px solid rgba(201,168,76,0.25);
+  border-radius: 14px;
+  padding: 40px 36px 32px;
+  width: 90%;
+  max-width: 520px;
+  box-shadow: 0 24px 80px rgba(0,0,0,0.6), 0 0 60px rgba(201,168,76,0.06);
+  animation: briefingSlideIn 0.4s ease;
+}
+@keyframes briefingSlideIn {
+  from { opacity: 0; transform: translateY(16px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+.briefing-header {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  margin-bottom: 24px;
+}
+.briefing-icon { width: 36px; height: 36px; flex-shrink: 0; }
+.briefing-title {
+  font-family: var(--font-display);
+  font-size: 26px;
+  color: var(--color-gold);
+  margin: 0;
+  letter-spacing: 0.03em;
+}
+.briefing-body {
+  font-family: var(--font-body);
+  font-size: 14.5px;
+  line-height: 1.7;
+  color: var(--color-text);
+}
+.briefing-body p { margin: 0 0 14px; }
+.briefing-body p:last-child { margin-bottom: 0; }
+.briefing-body strong { color: var(--color-gold); font-weight: 600; }
+.briefing-warning {
+  color: var(--color-text-muted);
+  font-style: italic;
+  border-top: 1px solid rgba(201,168,76,0.12);
+  padding-top: 14px;
+  margin-top: 18px !important;
+}
+.briefing-btn {
+  display: block;
+  width: 100%;
+  margin-top: 28px;
+  font-size: 16px;
+  padding: 12px 0;
+  letter-spacing: 0.04em;
+}
+
 /* ---- Footer ---- */
 .title-footer {
   position: absolute;


### PR DESCRIPTION
## Summary
- Adds a briefing overlay shown before new games start, explaining scarce resources (gold, iron, horses) and their strategic importance
- Invites players to use diplomacy: alliances, trade deals, secret pacts, dynastic marriages
- Flow: Play Now → auth checks → briefing overlay → Begin → game init (Continue bypasses briefing)

## Changes
- **index.html**: New briefing overlay div with parchment-style content
- **style.css**: Briefing panel styles matching existing dark/gold aesthetic
- **src/main.js**: Split startNewGame() into showGameBriefing() → launchGame()

## Test plan
- [ ] Click "Play Now" and verify briefing overlay appears
- [ ] Click "Begin" and verify game starts normally
- [ ] Click "Continue" and verify briefing does NOT appear
- [ ] Check mobile responsiveness of briefing panel