### PR TITLE
Capital promotion, elimination display, barbarian kill rewards

### DIFF
--- a/src/combat.js
+++ b/src/combat.js
@@ -6,7 +6,7 @@ import { addEvent, logAction, triggerEureka, triggerInspiration } from './events
 import { render, markVisibilityDirty } from './render.js';
 import { getModCombatBonus } from './diplomacy-api.js';
 import { revealAround } from './discovery.js';
-import { deselectUnit, autoSelectNext, isInEnemyZOC } from './units.js';
+import { deselectUnit, autoSelectNext, isInEnemyZOC, boostFactionReputation } from './units.js';
 import { updateUI } from './leaderboard.js';
 import { showToast } from './events.js';
 import { showModBanner } from './diplomacy-api.js';
@@ -153,10 +153,12 @@ function resolveCombat(attacker, defender) {
       if (attacker.type === 'slinger') triggerEureka('archery');
       // Spearman kill triggers military_tactics eureka
       if (attacker.type === 'spearman') triggerEureka('military_tactics');
-      // Barbarian kill tracking
+      // Barbarian kill tracking + diplomacy boost with nearby factions
       if (defender.owner === 'barbarian' || (defender.owner && defender.owner.startsWith && defender.owner.startsWith('barbarian'))) {
         game.barbarianKills = (game.barbarianKills || 0) + 1;
         if (game.barbarianKills >= 3) triggerEureka('bronze_working');
+        // Boost reputation with AI factions near the kill
+        boostFactionReputation(defender.col, defender.row, 'barbarian raiders');
       }
     }
   }
@@ -734,8 +736,28 @@ function captureFactionCity(factionId) {
     ...CITY_WALL_DEFAULTS,
   });
 
-  // Remove from faction cities
+  // Remove capital from faction cities
   delete game.factionCities[factionId];
+
+  // Promote first expansion city to capital if any remain
+  const expansionCities = game.aiFactionCities[factionId] || [];
+  if (expansionCities.length > 0) {
+    const promoted = expansionCities.shift();
+    game.factionCities[factionId] = {
+      name: promoted.name,
+      col: promoted.col,
+      row: promoted.row,
+      color: promoted.color || faction?.color || '#888',
+      hp: CITY_DEFENSE.BASE_HP,
+      population: promoted.population || 500,
+      borderRadius: Math.max(promoted.borderRadius || 1, 2),
+      improvements: promoted.improvements || 0,
+      wallHP: promoted.wallHP || 0,
+      wallMaxHP: promoted.wallMaxHP || 0,
+      wallLastAttackedTurn: promoted.wallLastAttackedTurn || -99,
+    };
+    addEvent(`${factionName} relocated their capital to ${promoted.name}!`, 'diplomacy');
+  }
 
   // Gain gold from plunder
   const plunderGold = 30 + Math.floor(Math.random() * 50);
@@ -780,8 +802,12 @@ function eliminateFaction(factionId, factionName) {
   // Remove any remaining expansion cities
   delete game.aiFactionCities[factionId];
 
-  // Remove from met factions tracking
-  // (keep metFactions entry so they still show in history)
+  // Track as eliminated (kept in metFactions for history/display)
+  if (!game.eliminatedFactions) game.eliminatedFactions = {};
+  game.eliminatedFactions[factionId] = { turn: game.turn, name: factionName };
+
+  // Remove from active diplomatic systems
+  delete game.factionStats[factionId];
 
   // Big score bonus
   game.score += 100;

--- a/src/improvements.js
+++ b/src/improvements.js
@@ -308,13 +308,17 @@ export function canFoundCityAt(col, row) {
   // Cannot found city in enemy territory
   const owner = getTileOwner(col, row);
   if (owner && owner !== 'player') return false;
-  // Must be 4+ hexes from any existing city
+  // Must be 4+ hexes from own cities, 6+ from foreign cities (border growth buffer)
   for (const city of game.cities) {
     if (hexDistance(col, row, city.col, city.row) < 4) return false;
   }
-  // Must be 4+ hexes from faction cities
-  for (const fc of Object.values(game.factionCities)) {
-    if (hexDistance(col, row, fc.col, fc.row) < 4) return false;
+  for (const [fid, fc] of Object.entries(game.factionCities || {})) {
+    if (hexDistance(col, row, fc.col, fc.row) < 6) return false;
+  }
+  for (const cities of Object.values(game.aiFactionCities || {})) {
+    for (const ec of cities) {
+      if (hexDistance(col, row, ec.col, ec.row) < 6) return false;
+    }
   }
   return true;
 }

--- a/src/intelligence.js
+++ b/src/intelligence.js
@@ -197,6 +197,15 @@ function renderOverview() {
     for (const fid of metFactions) {
       const faction = FACTIONS[fid];
       if (!faction) continue;
+      const isEliminated = game.eliminatedFactions?.[fid];
+      if (isEliminated) {
+        // Show dead faction with skull and elimination turn
+        html += `<div style="display:flex;align-items:center;justify-content:space-between;padding:4px 0;border-bottom:1px solid rgba(255,255,255,0.05);opacity:0.5;">`;
+        html += `<span style="color:#666;text-decoration:line-through;">${faction.icon||'\uD83C\uDFF0'} ${faction.name}</span>`;
+        html += `<span style="${S.badge}background:rgba(180,40,40,0.3);color:#d44;">\uD83D\uDC80 Eliminated (Turn ${isEliminated.turn})</span>`;
+        html += '</div>';
+        continue;
+      }
       const rel = game.relationships?.[fid] || 0;
       const label = getRelationLabel(rel);
       const threat = assessThreat(fid);

--- a/src/minor-factions.js
+++ b/src/minor-factions.js
@@ -310,7 +310,7 @@ window.barbCampAction = function(campId, action) {
       }
       // Success — camp disperses
       bc.destroyed = true;
-      const lootGold = Math.floor(bc.strength * 1.5) + 10;
+      const lootGold = 100;
       game.gold += lootGold;
       // Remove barbarian units near this camp
       game.units = game.units.filter(u => !(u.owner === 'barbarian' && hexDistance(u.col, u.row, bc.col, bc.row) <= 3));
@@ -376,7 +376,7 @@ window.barbCampAction = function(campId, action) {
       attacker.hp -= retaliation;
       if (bc.strength <= 0) {
         bc.destroyed = true;
-        const lootGold = 15 + Math.floor(Math.random() * 20);
+        const lootGold = 100;
         game.gold += lootGold;
         game.units = game.units.filter(u => !(u.owner === 'barbarian' && hexDistance(u.col, u.row, bc.col, bc.row) <= 2));
         // Track rebellion suppression for rebel camps
@@ -513,7 +513,7 @@ window.minorAction = function(mfId, action) {
         return;
       }
       mf.defeated = true;
-      const lootGold = Math.floor(mf.strength * 1.5) + 10;
+      const lootGold = 100;
       game.gold += lootGold;
       addEvent(`\u{1F4E2} The barbarians flee before your might! +${lootGold}g recovered.`, 'combat');
       showToast('Camp Dispersed', 'Your military strength forced the barbarians to abandon their camp.');
@@ -546,10 +546,11 @@ window.minorAction = function(mfId, action) {
         addEvent(`Your forces are not strong enough to destroy this camp (need ${mf.strength} military).`, 'combat');
         return;
       }
-      game.gold += mf.gold;
+      const destroyGold = 100;
+      game.gold += destroyGold;
       game.military -= Math.floor(mf.strength / 3);
       mf.defeated = true;
-      addEvent('\u{1F525} Barbarian camp destroyed! +' + mf.gold + ' gold', 'combat');
+      addEvent('\u{1F525} Barbarian camp destroyed! +' + destroyGold + ' gold', 'combat');
       break;
     }
     case 'commune': {

--- a/src/save-load.js
+++ b/src/save-load.js
@@ -140,6 +140,7 @@ function migrateTiles(state) {
   if (!state.minorFactions) state.minorFactions = [];
   if (!state.gameLog) state.gameLog = [];
   if (!state.aiCommitments) state.aiCommitments = [];
+  if (!state.eliminatedFactions) state.eliminatedFactions = {};
   if (!state.tribalVillages) state.tribalVillages = [];
   // --- District system migration ---
   if (!state.playerDistricts) state.playerDistricts = [];

--- a/src/turn.js
+++ b/src/turn.js
@@ -1581,15 +1581,21 @@ function canAIFoundCityAt(col, row, fid) {
   // Cannot found city in another faction's or the player's territory
   const owner = getTileOwner(col, row);
   if (owner && owner !== fid) return false;
+  // Must be far enough from any existing city (use max potential border to prevent
+  // the AI settling just outside current borders that will grow to engulf the city)
+  const MIN_DIST_OWN = 4;     // minimum distance from own cities
+  const MIN_DIST_OTHER = 6;   // minimum distance from other factions' cities (accounts for border growth)
   for (const city of game.cities) {
-    if (hexDistance(col, row, city.col, city.row) < 4) return false;
+    if (hexDistance(col, row, city.col, city.row) < MIN_DIST_OTHER) return false;
   }
-  for (const fc of Object.values(game.factionCities)) {
-    if (hexDistance(col, row, fc.col, fc.row) < 4) return false;
+  for (const [cfid, fc] of Object.entries(game.factionCities)) {
+    const minDist = cfid === fid ? MIN_DIST_OWN : MIN_DIST_OTHER;
+    if (hexDistance(col, row, fc.col, fc.row) < minDist) return false;
   }
-  for (const cities of Object.values(game.aiFactionCities || {})) {
+  for (const [cfid, cities] of Object.entries(game.aiFactionCities || {})) {
+    const minDist = cfid === fid ? MIN_DIST_OWN : MIN_DIST_OTHER;
     for (const ec of cities) {
-      if (hexDistance(col, row, ec.col, ec.row) < 4) return false;
+      if (hexDistance(col, row, ec.col, ec.row) < minDist) return false;
     }
   }
   return true;

--- a/src/units.js
+++ b/src/units.js
@@ -577,8 +577,8 @@ function checkAndClearBarbarianCamp(unit, col, row) {
 
 // ---- Boost reputation with nearby AI factions when clearing barbarian threats ----
 function boostFactionReputation(col, row, threatType) {
-  const REPUTATION_RANGE = 12; // How far away factions notice you clearing camps
-  const REPUTATION_BOOST = 8;  // +8 relationship points per camp cleared
+  const REPUTATION_RANGE = 14; // How far away factions notice you clearing threats
+  const REPUTATION_BOOST = 12; // +12 relationship points per threat cleared nearby
   if (!game.relationships) game.relationships = {};
 
   // Track best boost per faction (closest city = biggest boost, only applied once)
@@ -929,4 +929,5 @@ export {
   getEnemyZOCHexes,
   getTileOwner,
   isTerritoryBlocked,
+  boostFactionReputation,
 };

--- a/tests/combat-resolve.test.js
+++ b/tests/combat-resolve.test.js
@@ -355,23 +355,26 @@ describe('captureFactionCity()', () => {
     state = setupGameState();
   });
 
-  test('should not eliminate faction if they still have expansion cities', () => {
+  test('should promote expansion city to capital when capital is captured', () => {
     state.factionCities = {
       faction_a: { name: 'Capital', col: 5, row: 5, hp: 0, color: '#f00', population: 1000, borderRadius: 2 },
     };
     state.aiFactionCities = {
       faction_a: [
-        { name: 'Outpost', col: 10, row: 10, hp: 50, population: 500, borderRadius: 1 },
+        { name: 'Outpost', col: 10, row: 10, hp: 50, population: 500, borderRadius: 1, color: '#f00' },
       ],
     };
     state.units = [makeUnit({ id: 1, col: 5, row: 5, owner: 'player' })];
 
     captureFactionCity('faction_a');
 
-    // Capital removed
-    expect(state.factionCities.faction_a).toBeUndefined();
-    // Expansion city still exists — faction NOT eliminated
-    expect(state.aiFactionCities.faction_a).toHaveLength(1);
+    // Expansion city promoted to capital
+    expect(state.factionCities.faction_a).toBeDefined();
+    expect(state.factionCities.faction_a.name).toBe('Outpost');
+    expect(state.factionCities.faction_a.col).toBe(10);
+    // Expansion cities list is now empty (promoted out)
+    expect(state.aiFactionCities.faction_a).toHaveLength(0);
+    // Faction NOT eliminated
     expect(state.factionsEliminated || 0).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary

- **Capital promotion**: When AI capital is captured, first expansion city becomes new capital. Faction survives until ALL cities taken.
- **Elimination tracking**: Dead factions shown with skull icon and strikethrough in diplomacy overview. Excluded from AI diplomacy.
- **Barbarian kill diplomacy boost**: Killing barbarian units near AI territory now grants +12 reputation (up from 0).
- **100g camp reward**: Capturing/destroying barbarian camps always gives 100 gold (up from 15-35g).
- **6-hex rival city buffer**: AI/player cannot settle within 6 hexes of rival cities (from previous commit on this branch).

## Test plan

- [x] All 280 tests pass

https://claude.ai/code/session_01KnyFkgRNaNcGCpSoUK5hmL