### PR TITLE
Persistent diplomacy toasts, notification history, taller panel

### DIFF
--- a/src/ai-diplomacy.js
+++ b/src/ai-diplomacy.js
@@ -7,7 +7,7 @@
 
 import { FACTIONS, FACTION_TRAITS, RESOURCE_ZONES, UNIT_RESOURCE_REQUIREMENTS, RESOURCES } from './constants.js';
 import { game } from './state.js';
-import { addEvent, logAction, showToast } from './events.js';
+import { addEvent, logAction, showToast, showDiploToast } from './events.js';
 import { hexDistance } from './hex.js';
 import { hasResourceAccess } from './map.js';
 
@@ -210,7 +210,7 @@ function declareWar(a, b) {
   // PUBLIC — immediate event
   const msg = `War has broken out between ${factionA.name} and ${factionB.name}!`;
   addEvent(msg, 'diplomacy');
-  showToast('War Declared', msg, 5000);
+  showDiploToast('War Declared', msg);
   logAction('diplomacy', msg, { type: 'ai_war', attacker: a, defender: b });
 
   // Break any existing alliance or trade between them
@@ -464,7 +464,7 @@ function checkSecretPactActivation() {
     // Now PUBLIC — the secret is revealed through the joint declaration
     const msg = `${factionA.name} and ${factionB.name} suddenly declare war on ${factionT.name} simultaneously!`;
     addEvent(msg, 'diplomacy');
-    showToast('Secret Pact Revealed', msg, 6000);
+    showDiploToast('Secret Pact Revealed', msg);
     logAction('diplomacy', msg, {
       type: 'ai_secret_pact_activated', allies: [a, b], target,
     });
@@ -616,7 +616,7 @@ function processRumourQueue() {
   }
 
   if (newlyRevealed > 0) {
-    showToast('Rumours & Whispers', `${newlyRevealed} new rumour${newlyRevealed > 1 ? 's' : ''} heard`, 4000);
+    showDiploToast('Rumours & Whispers', `${newlyRevealed} new rumour${newlyRevealed > 1 ? 's' : ''} heard`);
   }
 }
 

--- a/src/combat.js
+++ b/src/combat.js
@@ -8,7 +8,7 @@ import { getModCombatBonus } from './diplomacy-api.js';
 import { revealAround } from './discovery.js';
 import { deselectUnit, autoSelectNext, isInEnemyZOC, boostFactionReputation } from './units.js';
 import { updateUI } from './leaderboard.js';
-import { showToast } from './events.js';
+import { showToast, showDiploToast } from './events.js';
 import { showModBanner } from './diplomacy-api.js';
 import { panCameraTo } from './input.js';
 import { startAnimLoop } from './feedback.js';
@@ -231,7 +231,7 @@ function declareSurpriseWar(factionId, factionName) {
   game.aiWars.push({ attacker: 'player', defender: factionId, startTurn: game.turn, turnsActive: 0 });
   const msg = `War declared on ${factionName}! (Surprise attack)`;
   addEvent(msg, 'diplomacy');
-  showToast('War Declared', msg, 5000);
+  showDiploToast('War Declared', msg);
   logAction('diplomacy', msg, { type: 'player_surprise_attack', defender: factionId });
 
   // Break all agreements with this faction
@@ -262,7 +262,7 @@ function declareSurpriseWar(factionId, factionName) {
     if (game.nonAggressionPacts) delete game.nonAggressionPacts[allyId];
     game.relationships[allyId] = Math.min(-50, (game.relationships[allyId] || 0) - 40);
     addEvent(`${allyName} has joined the war against you! (Allied with ${factionName})`, 'diplomacy');
-    showToast('War Escalation', `${allyName} joins the war!`, 5000);
+    showDiploToast('War Escalation', `${allyName} joins the war!`);
   }
 }
 
@@ -913,7 +913,7 @@ function aiRazePlayerCity(cityIdx, attackerFactionId) {
     : (FACTIONS[attackerFactionId]?.name || attackerFactionId);
 
   addEvent(`\u{1F525} ${attackerName} RAZED ${cityName}! The city is destroyed.`, 'combat');
-  showToast('City Razed', `${attackerName} razed ${cityName} to the ground!`, 6000);
+  showDiploToast('City Razed', `${attackerName} razed ${cityName} to the ground!`);
   logAction('combat', `${attackerName} razed ${cityName}`, { col, row, attackerFactionId });
 
   markVisibilityDirty();
@@ -979,7 +979,7 @@ function aiCapturePlayerCity(cityIdx, attackerFactionId) {
     });
 
     addEvent(`\u{1F3F0} ${factionName} captured ${cityName}!`, 'combat');
-    showToast('City Lost', `${factionName} captured ${cityName}!`, 6000);
+    showDiploToast('City Lost', `${factionName} captured ${cityName}!`);
     logAction('combat', `${factionName} captured ${cityName}`, { col, row, attackerFactionId });
 
     markVisibilityDirty();
@@ -1229,7 +1229,7 @@ function processZOCCaptures() {
     const captorName = c.capturedBy ? (FACTIONS[c.capturedBy]?.name || c.capturedBy) : 'unknown';
     if (c.prevOwner === 'player') {
       addEvent(`${name} captured by ${captorName} in their Zone of Control!`, 'combat');
-      showToast('Unit Captured!', `Your ${name} was captured by ${captorName} — no military escort nearby.`);
+      showDiploToast('Unit Captured!', `Your ${name} was captured by ${captorName} — no military escort nearby.`);
     } else if (c.capturedBy === 'player') {
       const prevName = FACTIONS[c.prevOwner]?.name || c.prevOwner;
       addEvent(`Captured ${prevName}'s ${name} in your Zone of Control!`, 'combat');

--- a/src/events.js
+++ b/src/events.js
@@ -59,15 +59,36 @@ export function showToast(title, message, duration) {
     document.body.appendChild(container);
   }
   const toast = document.createElement('div');
-  toast.style.cssText = 'background:rgba(20,20,30,0.92);border:1px solid rgba(255,215,0,0.5);border-radius:8px;padding:10px 16px;color:#f0e8d0;font-size:13px;max-width:300px;box-shadow:0 4px 16px rgba(0,0,0,0.5);opacity:0;transform:translateX(40px);transition:opacity 0.3s,transform 0.3s;pointer-events:auto;';
-  toast.innerHTML = '<div style="font-weight:bold;color:#ffd700;margin-bottom:2px">' + title + '</div>' + (message ? '<div style="color:#bbb;font-size:11px">' + message + '</div>' : '');
-  container.appendChild(toast);
-  requestAnimationFrame(() => { toast.style.opacity = '1'; toast.style.transform = 'translateX(0)'; });
-  setTimeout(() => {
+  toast.style.cssText = 'background:rgba(20,20,30,0.92);border:1px solid rgba(255,215,0,0.5);border-radius:8px;padding:10px 16px;color:#f0e8d0;font-size:13px;max-width:300px;box-shadow:0 4px 16px rgba(0,0,0,0.5);opacity:0;transform:translateX(40px);transition:opacity 0.3s,transform 0.3s;pointer-events:auto;cursor:pointer;';
+  toast.innerHTML = '<div style="display:flex;justify-content:space-between;align-items:start"><div><div style="font-weight:bold;color:#ffd700;margin-bottom:2px">' + title + '</div>' + (message ? '<div style="color:#bbb;font-size:11px">' + message + '</div>' : '') + '</div><span style="color:#666;font-size:16px;margin-left:8px;line-height:1">&times;</span></div>';
+  toast.onclick = () => {
     toast.style.opacity = '0';
     toast.style.transform = 'translateX(40px)';
-    setTimeout(() => { if (toast.parentNode) toast.parentNode.removeChild(toast); }, 350);
-  }, duration);
+    setTimeout(() => { if (toast.parentNode) toast.parentNode.removeChild(toast); }, 300);
+  };
+  container.appendChild(toast);
+  requestAnimationFrame(() => { toast.style.opacity = '1'; toast.style.transform = 'translateX(0)'; });
+  if (duration > 0) {
+    setTimeout(() => {
+      toast.style.opacity = '0';
+      toast.style.transform = 'translateX(40px)';
+      setTimeout(() => { if (toast.parentNode) toast.parentNode.removeChild(toast); }, 350);
+    }, duration);
+  }
+}
+
+/**
+ * Show a diplomacy toast that persists until dismissed (clicked) and
+ * logs the notification to game.diploNotifications for the Ledger tab.
+ */
+export function showDiploToast(title, message) {
+  // Persist until clicked (duration=0 means no auto-dismiss)
+  showToast(title, message, 0);
+  // Log to persistent notification history
+  if (!game.diploNotifications) game.diploNotifications = [];
+  game.diploNotifications.push({ title, message, turn: game.turn });
+  // Cap at 50 entries
+  while (game.diploNotifications.length > 50) game.diploNotifications.shift();
 }
 
 // ============================================

--- a/src/intelligence.js
+++ b/src/intelligence.js
@@ -417,6 +417,24 @@ function renderRumoursTab() {
 
 function renderLedgerTab() {
   let html = '';
+
+  // Diplomatic notifications (persistent toast history)
+  const notifications = game.diploNotifications || [];
+  if (notifications.length > 0) {
+    html += `<div style="${S.card}">`;
+    html += `<div style="${S.cardHd}"><strong>\uD83D\uDD14 Diplomatic Notifications</strong></div>`;
+    for (const notif of [...notifications].reverse().slice(0, 20)) {
+      const turnLabel = notif.turn !== undefined ? `Turn ${notif.turn}` : '';
+      html += `<div style="padding:3px 0;font-size:11px;border-bottom:1px solid rgba(255,255,255,0.03);">`;
+      html += `<span style="color:#888;display:inline-block;width:50px;">${turnLabel}</span>`;
+      html += `<strong style="color:#ffd700;">${notif.title}</strong>`;
+      if (notif.message) html += ` <span style="color:#aaa;">${notif.message}</span>`;
+      html += '</div>';
+    }
+    if (notifications.length > 20) html += `<div style="color:#888;font-size:10px;text-align:center;margin-top:4px;">Showing 20 of ${notifications.length}</div>`;
+    html += '</div>';
+  }
+
   const allEntries = [];
   const ledger = game.diplomaticLedger || {};
   for (const [fid, entries] of Object.entries(ledger)) {
@@ -424,7 +442,7 @@ function renderLedgerTab() {
   }
   allEntries.sort((a, b) => (b.turn || 0) - (a.turn || 0));
 
-  if (allEntries.length === 0) {
+  if (allEntries.length === 0 && notifications.length === 0) {
     html += `<div style="${S.card}color:#666;font-style:italic;">The diplomatic ledger is empty. Your scribes await events to record.</div>`;
     return html;
   }

--- a/src/save-load.js
+++ b/src/save-load.js
@@ -141,6 +141,7 @@ function migrateTiles(state) {
   if (!state.gameLog) state.gameLog = [];
   if (!state.aiCommitments) state.aiCommitments = [];
   if (!state.eliminatedFactions) state.eliminatedFactions = {};
+  if (!state.diploNotifications) state.diploNotifications = [];
   if (!state.tribalVillages) state.tribalVillages = [];
   // --- District system migration ---
   if (!state.playerDistricts) state.playerDistricts = [];

--- a/style.css
+++ b/style.css
@@ -648,7 +648,7 @@ a:hover { text-decoration: underline; }
   left: 50%;
   transform: translate(-50%, -50%);
   width: min(500px, 90vw);
-  max-height: 80vh;
+  max-height: 90vh;
 }
 
 .char-card {


### PR DESCRIPTION
## Summary

- Diplomacy toasts persist until clicked (no auto-fade)
- All diplomacy notifications logged to Ledger tab in diplomacy dashboard
- Diplomacy panel max-height increased to 90vh (shows all 6 opponents without scrolling)

## Test plan

- [x] All 280 tests pass

https://claude.ai/code/session_01KnyFkgRNaNcGCpSoUK5hmL