### PR TITLE
Release: Fix improvement rendering, territory cache, great generals

### DIFF
--- a/src/combat.js
+++ b/src/combat.js
@@ -6,7 +6,7 @@ import { addEvent, logAction, triggerEureka, triggerInspiration } from './events
 import { render, markVisibilityDirty } from './render.js';
 import { getModCombatBonus } from './diplomacy-api.js';
 import { revealAround } from './discovery.js';
-import { deselectUnit, autoSelectNext, isInEnemyZOC, boostFactionReputation } from './units.js';
+import { deselectUnit, autoSelectNext, isInEnemyZOC, boostFactionReputation, releaseGeneralArmy } from './units.js';
 import { updateUI } from './leaderboard.js';
 import { showToast, showDiploToast } from './events.js';
 import { showModBanner } from './diplomacy-api.js';
@@ -21,22 +21,8 @@ function resolveCombat(attacker, defender) {
   const aType = UNIT_TYPES[attacker.type];
   const dType = UNIT_TYPES[defender.type] || { name: 'City', combat: 15, rangedCombat: 0, range: 0, movePoints: 0, icon: '\u{1F3F0}', class: 'city', desc: 'Fortified city' };
 
-  // Civilian capture — attacker takes ownership (great generals are killed instead)
+  // Civilian capture — attacker takes ownership
   if (dType.class === 'civilian') {
-    if (defender.type === 'great_general') {
-      // Great generals cannot be captured — they are killed
-      const prevOwner = defender.owner;
-      addDeathMarker(defender.col, defender.row);
-      game.units = game.units.filter(u => u.id !== defender.id);
-      const ownerName = FACTIONS[prevOwner]?.name || prevOwner;
-      const captorName = FACTIONS[attacker.owner]?.name || attacker.owner;
-      if (prevOwner === 'player') {
-        addEvent(`Your Great General was slain by ${captorName}!`, 'combat');
-      } else if (attacker.owner === 'player') {
-        addEvent(`Slew ${ownerName}'s Great General!`, 'combat');
-      }
-      return { attackerDied: false, defenderDied: true, captured: false };
-    }
     const prevOwner = defender.owner;
     defender.owner = attacker.owner;
     defender.moveLeft = 0;
@@ -153,6 +139,8 @@ function resolveCombat(attacker, defender) {
   // Remove dead units
   if (defender.hp <= 0) {
     addDeathMarker(defender.col, defender.row);
+    // Release army units before removing the general
+    if (defender.type === 'great_general') releaseGeneralArmy(defender);
     game.units = game.units.filter(u => u.id !== defender.id);
     markVisibilityDirty();
     result.defenderDied = true;
@@ -1296,7 +1284,8 @@ function processZOCCaptures() {
   for (let i = game.units.length - 1; i >= 0; i--) {
     const unit = game.units[i];
     const ut = UNIT_TYPES[unit.type];
-    if (!ut || !ZOC_EXEMPT_CLASSES.includes(ut.class)) continue; // only civilians
+    if (!ut || !ZOC_EXEMPT_CLASSES.includes(ut.class)) continue; // only non-combat units
+    if (ut.class === 'great_person') continue; // great persons are immune to ZOC capture
 
     if (!isInEnemyZOC(unit.col, unit.row, unit.owner)) continue;
 
@@ -1336,13 +1325,6 @@ function processZOCCaptures() {
       }
 
       captured.push({ type: unit.type, prevOwner: unit.owner, col: unit.col, row: unit.row, capturedBy });
-
-      // Great generals are killed, not captured
-      if (unit.type === 'great_general') {
-        addDeathMarker(unit.col, unit.row);
-        game.units.splice(i, 1);
-        continue;
-      }
 
       // Transfer to capturing faction instead of deleting
       if (capturedBy) {

--- a/src/constants.js
+++ b/src/constants.js
@@ -66,13 +66,14 @@ export let UNIT_TYPES = {
   ballista:  { name: 'Ballista', cost: 50, combat: 10, rangedCombat: 30, range: 2, movePoints: 1, icon: '\u{1F3AF}', class: 'siege', desc: 'Siege engine, +50% vs cities' },
   galley:    { name: 'Galley', cost: 35, combat: 25, rangedCombat: 0, range: 0, movePoints: 3, icon: '\u{26F5}', class: 'naval', desc: 'Coastal patrol vessel' },
   phalanx:   { name: 'Phalanx', cost: 40, combat: 30, rangedCombat: 0, range: 0, movePoints: 2, icon: '\u{1F6E1}', class: 'anti-cav', desc: 'Heavy infantry, +15 vs cavalry' },
-  great_general: { name: 'Great General', cost: 0, combat: 0, rangedCombat: 0, range: 0, movePoints: 3, icon: '\u{2694}', class: 'civilian', desc: 'Legendary commander. Attach military units to form an army that moves and fights together.' },
+  great_general: { name: 'Great General', cost: 0, combat: 0, rangedCombat: 0, range: 0, movePoints: 3, icon: '\u{2694}', class: 'great_person', desc: 'Legendary commander. Attach military units to form an army that moves and fights together.' },
 };
 
 // ============================================
-// ZONE OF CONTROL — civilian units don't project ZOC (but are still affected by it)
+// ZONE OF CONTROL — civilian and great_person units don't project ZOC.
+// Civilians can be captured in ZOC; great_persons are immune to ZOC capture.
 // ============================================
-export const ZOC_EXEMPT_CLASSES = ['civilian'];
+export const ZOC_EXEMPT_CLASSES = ['civilian', 'great_person'];
 
 // ============================================
 // UNIT UPGRADE PATHS

--- a/src/render.js
+++ b/src/render.js
@@ -1095,8 +1095,8 @@ function render() {
     // Unit vertical offset — shift down to avoid overlapping city icons
     let uy = sy + 12;
 
-    // Stacking offset: if a civilian shares a tile with a military unit, offset the civilian
-    const isCiv = ut.class === 'civilian';
+    // Stacking offset: if a non-combat unit shares a tile with a military unit, offset the non-combat unit
+    const isCiv = ut.class === 'civilian' || ut.class === 'great_person';
     const stackPartner = game.units.find(u => u.id !== unit.id && u.col === unit.col && u.row === unit.row && u.owner === unit.owner);
     if (stackPartner && isCiv) {
       sx += 12;

--- a/src/render.js
+++ b/src/render.js
@@ -110,6 +110,157 @@ function drawCapitalStar(cx, sx, sy, color) {
   cx.restore();
 }
 
+// ============================================
+// TERRAIN-AWARE IMPROVEMENT RENDERING
+// ============================================
+
+// Offscreen canvas for terrain-tinted improvement compositing
+let _impCanvas = null;
+let _impCtx = null;
+function getImpCanvas() {
+  if (!_impCanvas) {
+    _impCanvas = document.createElement('canvas');
+    _impCanvas.width = 128;
+    _impCanvas.height = 128;
+    _impCtx = _impCanvas.getContext('2d');
+  }
+  return { cv: _impCanvas, cx: _impCtx };
+}
+
+// Per-improvement layout: how big relative to hex, and vertical offset
+// Positive dy = lower in hex. Scale is fraction of HEX_SIZE*2
+const IMP_LAYOUT = {
+  farm:          { scale: 0.72, dy:  0.18, dx: 0 },
+  irrigation:    { scale: 0.70, dy:  0.15, dx: 0 },
+  pasture:       { scale: 0.68, dy:  0.12, dx: 0 },
+  camp:          { scale: 0.62, dy:  0.05, dx: 0 },
+  fishing_boats: { scale: 0.70, dy:  0.20, dx: 0 },
+  mine:          { scale: 0.65, dy: -0.15, dx: 0 },
+  quarry:        { scale: 0.65, dy: -0.12, dx: 0.05 },
+  lumber_mill:   { scale: 0.70, dy:  0.00, dx: 0 },
+};
+
+// Tint strength per terrain — how much the terrain colour shifts the sprite
+const TINT_STRENGTH = 0.35;
+
+// Simple deterministic hash from tile coordinates — stable per tile, no flicker
+function tileHash(col, row) {
+  return ((col * 7919) + (row * 104729)) & 0xFFFF;
+}
+
+// Draw a terrain-tinted, contextually-positioned improvement sprite
+function drawTintedImprovement(mainCtx, impImg, tile, sx, sy, col, row) {
+  const layout = IMP_LAYOUT[tile.improvement] || { scale: 0.65, dy: 0, dx: 0 };
+  const spriteSize = HEX_SIZE * 2 * layout.scale;
+
+  // Deterministic mirror based on tile position (~50% of tiles get flipped)
+  const mirror = (tileHash(col, row) % 2) === 0;
+
+  // Get terrain base colour for tinting
+  const terrainKey = tile.feature || tile.base;
+  const tintRGB = BASE_COLORS[terrainKey] || BASE_COLORS[tile.base];
+
+  // Position offset within the hex (flip dx when mirrored)
+  const ox = sx + (mirror ? -layout.dx : layout.dx) * HEX_SIZE;
+  const oy = sy + layout.dy * HEX_SIZE;
+
+  if (!tintRGB) {
+    // Fallback: no tinting, just draw smaller + positioned (still mirror)
+    mainCtx.save();
+    mainCtx.globalAlpha = 0.8;
+    if (mirror) {
+      mainCtx.translate(ox, oy);
+      mainCtx.scale(-1, 1);
+      mainCtx.drawImage(impImg, -spriteSize/2, -spriteSize/2, spriteSize, spriteSize);
+    } else {
+      mainCtx.drawImage(impImg, ox - spriteSize/2, oy - spriteSize/2, spriteSize, spriteSize);
+    }
+    mainCtx.globalAlpha = 1.0;
+    mainCtx.restore();
+    return;
+  }
+
+  // Composite on offscreen canvas: sprite × terrain colour
+  const { cv, cx } = getImpCanvas();
+  const cSize = cv.width;
+
+  // 1) Clear
+  cx.clearRect(0, 0, cSize, cSize);
+
+  // 2) Draw the improvement sprite (mirror on the offscreen canvas if needed)
+  cx.globalCompositeOperation = 'source-over';
+  if (mirror) {
+    cx.save(); cx.translate(cSize, 0); cx.scale(-1, 1);
+    cx.drawImage(impImg, 0, 0, cSize, cSize); cx.restore();
+  } else {
+    cx.drawImage(impImg, 0, 0, cSize, cSize);
+  }
+
+  // 3) Multiply-blend with terrain colour
+  cx.globalCompositeOperation = 'multiply';
+  const r = Math.round(tintRGB[0] + (255 - tintRGB[0]) * (1 - TINT_STRENGTH));
+  const g = Math.round(tintRGB[1] + (255 - tintRGB[1]) * (1 - TINT_STRENGTH));
+  const b = Math.round(tintRGB[2] + (255 - tintRGB[2]) * (1 - TINT_STRENGTH));
+  cx.fillStyle = `rgb(${r},${g},${b})`;
+  cx.fillRect(0, 0, cSize, cSize);
+
+  // 4) Restore alpha from original sprite (multiply kills transparency)
+  cx.globalCompositeOperation = 'destination-in';
+  if (mirror) {
+    cx.save(); cx.translate(cSize, 0); cx.scale(-1, 1);
+    cx.drawImage(impImg, 0, 0, cSize, cSize); cx.restore();
+  } else {
+    cx.drawImage(impImg, 0, 0, cSize, cSize);
+  }
+  cx.globalCompositeOperation = 'source-over';
+
+  // 5) Draw the tinted result onto the main canvas
+  mainCtx.save();
+  mainCtx.globalAlpha = 0.82;
+  mainCtx.drawImage(cv, ox - spriteSize/2, oy - spriteSize/2, spriteSize, spriteSize);
+  mainCtx.globalAlpha = 1.0;
+  mainCtx.restore();
+}
+
+// Draw roads as connecting paths between hex centres
+function drawRoadConnections(mainCtx, tile, c, r, sx, sy, camOffX, camOffY) {
+  const neighbors = getHexNeighbors(c, r);
+  let hasConnection = false;
+
+  mainCtx.save();
+  mainCtx.strokeStyle = 'rgba(140,115,70,0.55)';
+  mainCtx.lineWidth = HEX_SIZE * 0.14;
+  mainCtx.lineCap = 'round';
+
+  for (const n of neighbors) {
+    if (n.row < 0 || n.row >= MAP_ROWS || n.col < 0 || n.col >= MAP_COLS) continue;
+    const nTile = game.map[n.row][n.col];
+    if (!nTile.road) continue;
+
+    hasConnection = true;
+    const nPos = hexToPixel(n.col, n.row);
+    const nx = nPos.x - camOffX;
+    const ny = nPos.y - camOffY;
+
+    const edgeX = (sx + nx) / 2;
+    const edgeY = (sy + ny) / 2;
+
+    mainCtx.beginPath();
+    mainCtx.moveTo(sx, sy);
+    mainCtx.lineTo(edgeX, edgeY);
+    mainCtx.stroke();
+  }
+
+  if (!hasConnection) {
+    mainCtx.fillStyle = 'rgba(140,115,70,0.4)';
+    mainCtx.beginPath();
+    mainCtx.arc(sx, sy, HEX_SIZE * 0.12, 0, Math.PI * 2);
+    mainCtx.fill();
+  }
+
+  mainCtx.restore();
+}
+
 function resizeCanvas() {
   const w = canvas.parentElement.clientWidth;
   const h = canvas.parentElement.clientHeight;
@@ -355,89 +506,15 @@ function render() {
       }
 
       // Draw tile improvements as images
+      // Draw roads as connecting paths (render before improvements so they sit beneath)
+      if (tile.road) {
+        drawRoadConnections(ctx, tile, c, r, sx, sy, camX, camY);
+      }
+      // Draw tile improvements — terrain-tinted, partial coverage, randomly mirrored
       if (tile.improvement) {
         const impImg = IMPROVEMENT_IMAGES[tile.improvement];
         if (impImg && impImg.complete && impImg.naturalWidth > 0) {
-          ctx.save();
-          ctx.globalAlpha = 0.75;
-          const impS = HEX_SIZE * 2.3;
-          ctx.drawImage(impImg, sx - impS/2, sy - impS/2, impS, impS);
-          ctx.globalAlpha = 1.0;
-          ctx.restore();
-        }
-      }
-      // Draw fortification overlay
-      if (tile.fortification) {
-        const fortImg = IMPROVEMENT_IMAGES['fortification'];
-        if (fortImg && fortImg.complete && fortImg.naturalWidth > 0) {
-          ctx.save();
-          ctx.globalAlpha = 0.75;
-          const fortS = HEX_SIZE * 2.3;
-          ctx.drawImage(fortImg, sx - fortS/2, sy - fortS/2, fortS, fortS);
-          ctx.globalAlpha = 1.0;
-          ctx.restore();
-        }
-      }
-      // Draw district sprites (rendered on top of terrain, below units)
-      if (tile.district) {
-        const distImg = IMPROVEMENT_IMAGES['district_' + tile.district];
-        if (distImg && distImg.complete && distImg.naturalWidth > 0) {
-          ctx.save();
-          // Clip to hex shape
-          ctx.beginPath();
-          for (let i = 0; i < 6; i++) {
-            const angle = Math.PI / 180 * (60 * i - 30);
-            const hx = sx + HEX_SIZE * Math.cos(angle);
-            const hy = sy + HEX_SIZE * Math.sin(angle);
-            if (i === 0) ctx.moveTo(hx, hy); else ctx.lineTo(hx, hy);
-          }
-          ctx.closePath();
-          ctx.clip();
-          ctx.globalAlpha = 0.85;
-          const distS = HEX_SIZE * 2.3;
-
-          // Harbour: rotate sprite to face adjacent water
-          let distRotation = 0;
-          if (tile.district === 'harbor') {
-            const nbs = getHexNeighbors(c, r);
-            // Average the direction vectors toward all adjacent water tiles
-            let wx = 0, wy = 0, waterCount = 0;
-            for (const nb of nbs) {
-              const nt = game.map[nb.row] && game.map[nb.row][nb.col];
-              if (nt && (nt.base === 'ocean' || nt.base === 'coast' || nt.base === 'lake')) {
-                const { x: nbx, y: nby } = hexToPixel(nb.col, nb.row);
-                wx += nbx - sx; wy += nby - sy;
-                waterCount++;
-              }
-            }
-            if (waterCount > 0) {
-              // Sprite default faces south (π/2 rad = down).
-              // Rotate so the dock side points toward water.
-              const waterAngle = Math.atan2(wy, wx);
-              distRotation = waterAngle - Math.PI / 2; // offset from default south-facing
-            }
-          }
-
-          if (distRotation !== 0) {
-            ctx.translate(sx, sy);
-            ctx.rotate(distRotation);
-            ctx.drawImage(distImg, -distS/2, -distS/2, distS, distS);
-          } else {
-            ctx.drawImage(distImg, sx - distS/2, sy - distS/2, distS, distS);
-          }
-          ctx.globalAlpha = 1.0;
-          ctx.restore();
-        }
-      }
-      if (tile.road) {
-        const roadImg = IMPROVEMENT_IMAGES['road'];
-        if (roadImg && roadImg.complete && roadImg.naturalWidth > 0) {
-          ctx.save();
-          ctx.globalAlpha = 0.5;
-          const rS = HEX_SIZE * 2.2;
-          ctx.drawImage(roadImg, sx - rS/2, sy - rS/2, rS, rS);
-          ctx.globalAlpha = 1.0;
-          ctx.restore();
+          drawTintedImprovement(ctx, impImg, tile, sx, sy, c, r);
         }
       }
       // Show improvement in progress (circular progress indicator)

--- a/src/render.js
+++ b/src/render.js
@@ -1,4 +1,4 @@
-import { HEX_SIZE, SQRT3, MAP_COLS, MAP_ROWS, BASE_TERRAIN, TERRAIN_FEATURES, RESOURCES, UNIT_TYPES, FACTIONS, NATURAL_WONDERS, TILE_IMPROVEMENTS, UNIT_SPRITE_MAP, ZOOM_MIN, ZOOM_MAX, CITY_DEFENSE, BARBARIAN_UNITS, BUILDINGS, WONDERS, WALL_HP, DISTRICTS } from './constants.js';
+import { HEX_SIZE, SQRT3, MAP_COLS, MAP_ROWS, BASE_TERRAIN, TERRAIN_FEATURES, RESOURCES, UNIT_TYPES, FACTIONS, NATURAL_WONDERS, TILE_IMPROVEMENTS, UNIT_SPRITE_MAP, ZOOM_MIN, ZOOM_MAX, CITY_DEFENSE, BARBARIAN_UNITS, BUILDINGS, WONDERS, WALL_HP, DISTRICTS, BASE_COLORS } from './constants.js';
 import { game, canvas, ctx, miniCanvas, miniCtx, canvasW, canvasH, setCanvasSize, gameZoom, setGameZoom, hoveredHex, LOCKED_DPR, tilesLoaded, TERRAIN_TILE_IMAGES, IMPROVEMENT_IMAGES, SETTLEMENT_IMAGES, unitAtlas, NEW_UNIT_SPRITES, animRunning, deathMarkers } from './state.js';
 import { hexToPixel, pixelToHex, drawHex, getHexNeighbors, hexDistance } from './hex.js';
 import { valueNoise, fbmNoise, rgbStr, adjustBrightness, hexToRgba, getTerrainTileImage } from './utils.js';
@@ -362,6 +362,7 @@ function computeVisibility() {
 
 function render() {
   if (!game) return;
+  if (!ctx) return;
   // Kick off idle sprite animation loop on first render
   startSpriteAnimLoop();
   // Reset transform unconditionally — prevents accumulated scale from corrupted

--- a/src/render.js
+++ b/src/render.js
@@ -254,6 +254,63 @@ function render() {
   // ZOC overlay: show enemy ZOC hexes when a player unit is selected
   const zocHexes = game.selectedUnitId ? getEnemyZOCHexes('player') : null;
 
+  // Pre-compute territory ownership for the viewport (+ 2-tile buffer for border lookups).
+  // This avoids recomputing ownership 7× per hex (once for the hex + once per neighbour)
+  // which was causing severe GC pressure and frame drops on mid/late-game maps.
+  const _tBuf = 2;
+  const _tR0 = Math.max(0, startRow - _tBuf);
+  const _tR1 = Math.min(MAP_ROWS, endRow + _tBuf);
+  const _tC0 = Math.max(0, startCol - _tBuf);
+  const _tC1 = Math.min(MAP_COLS, endCol + _tBuf);
+  // _tOwner is keyed by r*MAP_COLS+c; value is { owner, color } or undefined (unclaimed)
+  const _tOwner = new Array(MAP_ROWS * MAP_COLS); // sparse — only territory hexes are set
+  // Pre-build per-faction city lists once (avoids allCities array creation in inner loop)
+  const _factionCityLists = []; // [{ fid, color, cities[] }]
+  for (const [fid, fc] of Object.entries(game.factionCities)) {
+    if (!fc.color) continue;
+    _factionCityLists.push({ fid, color: fc.color, cities: [fc, ...(game.aiFactionCities?.[fid] || [])] });
+  }
+  const _expansionOnlyLists = []; // factions with expansion cities but no capital
+  if (game.aiFactionCities) {
+    for (const [fid, cities] of Object.entries(game.aiFactionCities)) {
+      if (!game.factionCities[fid]) _expansionOnlyLists.push({ fid, cities });
+    }
+  }
+  for (let r = _tR0; r < _tR1; r++) {
+    for (let c = _tC0; c < _tC1; c++) {
+      let bestClaim = 0, hexOwner = null, hexColor = null;
+      for (const city of (game.cities || [])) {
+        const d = hexDistance(c, r, city.col, city.row);
+        const br = city.borderRadius || 2;
+        if (d <= br) {
+          const claim = (br - d + 1) + (city.cultureAccum || 0) * 0.01;
+          if (claim > bestClaim) { bestClaim = claim; hexOwner = 'player'; hexColor = 'player'; }
+        }
+      }
+      for (const { fid, color, cities } of _factionCityLists) {
+        for (const city of cities) {
+          const d = hexDistance(c, r, city.col, city.row);
+          const br = city.borderRadius || 2;
+          if (d <= br) {
+            const claim = (br - d + 1) + ((city.cultureAccum || 0) * 0.01);
+            if (claim > bestClaim) { bestClaim = claim; hexOwner = fid; hexColor = color; }
+          }
+        }
+      }
+      for (const { fid, cities } of _expansionOnlyLists) {
+        for (const city of cities) {
+          const d = hexDistance(c, r, city.col, city.row);
+          const br = city.borderRadius || 1;
+          if (d <= br) {
+            const claim = (br - d + 1);
+            if (claim > bestClaim) { bestClaim = claim; hexOwner = fid; hexColor = city.color || '#888888'; }
+          }
+        }
+      }
+      if (hexOwner) _tOwner[r * MAP_COLS + c] = { owner: hexOwner, color: hexColor };
+    }
+  }
+
   // Draw hex tiles
   for (let r = startRow; r < endRow; r++) {
     for (let c = startCol; c < endCol; c++) {
@@ -466,106 +523,26 @@ function render() {
         ctx.textBaseline = 'alphabetic';
       }
 
-      // Unified territory rendering — each hex belongs to exactly one owner
+      // Territory rendering — uses pre-computed ownership cache
       {
-        // Find the exclusive owner of this hex (closest city by culture strength)
-        let hexOwner = null, hexColor = null, bestClaim = 0;
-        // Player cities
-        for (const city of game.cities) {
-          const d = hexDistance(c, r, city.col, city.row);
-          const br = city.borderRadius || 2;
-          if (d <= br) {
-            const claim = (br - d + 1) + (city.cultureAccum || 0) * 0.01;
-            if (claim > bestClaim) { bestClaim = claim; hexOwner = 'player'; hexColor = 'rgba(201,168,76,'; }
-          }
-        }
-        // Faction cities (capital + expansion)
-        for (const [fid, fc] of Object.entries(game.factionCities)) {
-          if (!fc.color) continue;
-          const allCities = [fc, ...(game.aiFactionCities?.[fid] || [])];
-          for (const city of allCities) {
-            const d = hexDistance(c, r, city.col, city.row);
-            const br = city.borderRadius || 2;
-            if (d <= br) {
-              const claim = (br - d + 1) + ((city.cultureAccum || 0) * 0.01);
-              if (claim > bestClaim) { bestClaim = claim; hexOwner = fid; hexColor = fc.color; }
-            }
-          }
-        }
-        // Also check expansion cities of factions without a capital
-        if (game.aiFactionCities) {
-          for (const [fid, cities] of Object.entries(game.aiFactionCities)) {
-            if (game.factionCities[fid]) continue; // already checked above
-            for (const city of cities) {
-              const d = hexDistance(c, r, city.col, city.row);
-              const br = city.borderRadius || 1;
-              if (d <= br) {
-                const claim = (br - d + 1);
-                if (claim > bestClaim) { bestClaim = claim; hexOwner = fid; hexColor = city.color || '#888'; }
-              }
-            }
-          }
-        }
-
-        if (hexOwner) {
+        const tEntry = _tOwner[r * MAP_COLS + c];
+        if (tEntry) {
+          const { owner: hexOwner, color: hexColor } = tEntry;
           // Territory fill
           drawHex(ctx, sx, sy, HEX_SIZE - 1);
-          if (hexOwner === 'player') {
-            ctx.fillStyle = 'rgba(201,168,76,0.06)';
-          } else {
-            ctx.fillStyle = hexToRgba(hexColor, 0.05);
-          }
+          ctx.fillStyle = hexOwner === 'player' ? 'rgba(201,168,76,0.06)' : hexToRgba(hexColor, 0.05);
           ctx.fill();
 
-          // Border edges — draw where neighbor has a different owner
+          // Border edges — draw where neighbour has a different owner (cache lookup, no recompute)
           const nbs = getHexNeighbors(c, r);
           for (const nb of nbs) {
-            // Compute neighbor's owner using same logic
-            let nbOwner = null, nbBest = 0;
-            for (const city of game.cities) {
-              const d = hexDistance(nb.col, nb.row, city.col, city.row);
-              const br = city.borderRadius || 2;
-              if (d <= br) {
-                const claim = (br - d + 1) + (city.cultureAccum || 0) * 0.01;
-                if (claim > nbBest) { nbBest = claim; nbOwner = 'player'; }
-              }
-            }
-            for (const [fid, fc] of Object.entries(game.factionCities)) {
-              if (!fc.color) continue;
-              const allCities = [fc, ...(game.aiFactionCities?.[fid] || [])];
-              for (const city of allCities) {
-                const d = hexDistance(nb.col, nb.row, city.col, city.row);
-                const br = city.borderRadius || 2;
-                if (d <= br) {
-                  const claim = (br - d + 1) + ((city.cultureAccum || 0) * 0.01);
-                  if (claim > nbBest) { nbBest = claim; nbOwner = fid; }
-                }
-              }
-            }
-            if (game.aiFactionCities) {
-              for (const [fid, cities] of Object.entries(game.aiFactionCities)) {
-                if (game.factionCities[fid]) continue;
-                for (const city of cities) {
-                  const d = hexDistance(nb.col, nb.row, city.col, city.row);
-                  const br = city.borderRadius || 1;
-                  if (d <= br) {
-                    const claim = (br - d + 1);
-                    if (claim > nbBest) { nbBest = claim; nbOwner = fid; }
-                  }
-                }
-              }
-            }
-
-            // Draw border if neighbor is different owner (or unclaimed)
+            const nbEntry = _tOwner[nb.row * MAP_COLS + nb.col];
+            const nbOwner = nbEntry ? nbEntry.owner : null;
             if (nbOwner !== hexOwner) {
               const nbPos = hexToPixel(nb.col, nb.row);
               const edx = (nbPos.x - (sx + camX)) * 0.48;
               const edy = (nbPos.y - (sy + camY)) * 0.48;
-              if (hexOwner === 'player') {
-                ctx.strokeStyle = 'rgba(201,168,76,0.6)';
-              } else {
-                ctx.strokeStyle = hexToRgba(hexColor, 0.6);
-              }
+              ctx.strokeStyle = hexOwner === 'player' ? 'rgba(201,168,76,0.6)' : hexToRgba(hexColor, 0.6);
               ctx.lineWidth = 2.5;
               ctx.beginPath();
               ctx.moveTo(sx + edx - edy * 0.5, sy + edy + edx * 0.5);

--- a/src/render.js
+++ b/src/render.js
@@ -1,4 +1,4 @@
-import { HEX_SIZE, SQRT3, MAP_COLS, MAP_ROWS, BASE_TERRAIN, TERRAIN_FEATURES, RESOURCES, UNIT_TYPES, FACTIONS, NATURAL_WONDERS, TILE_IMPROVEMENTS, UNIT_SPRITE_MAP, ZOOM_MIN, ZOOM_MAX, CITY_DEFENSE, BARBARIAN_UNITS, BUILDINGS, WONDERS, WALL_HP, DISTRICTS, BASE_COLORS } from './constants.js';
+import { HEX_SIZE, SQRT3, MAP_COLS, MAP_ROWS, BASE_TERRAIN, TERRAIN_FEATURES, RESOURCES, UNIT_TYPES, FACTIONS, NATURAL_WONDERS, TILE_IMPROVEMENTS, UNIT_SPRITE_MAP, ZOOM_MIN, ZOOM_MAX, CITY_DEFENSE, BARBARIAN_UNITS, BUILDINGS, WONDERS, WALL_HP, DISTRICTS } from './constants.js';
 import { game, canvas, ctx, miniCanvas, miniCtx, canvasW, canvasH, setCanvasSize, gameZoom, setGameZoom, hoveredHex, LOCKED_DPR, tilesLoaded, TERRAIN_TILE_IMAGES, IMPROVEMENT_IMAGES, SETTLEMENT_IMAGES, unitAtlas, NEW_UNIT_SPRITES, animRunning, deathMarkers } from './state.js';
 import { hexToPixel, pixelToHex, drawHex, getHexNeighbors, hexDistance } from './hex.js';
 import { valueNoise, fbmNoise, rgbStr, adjustBrightness, hexToRgba, getTerrainTileImage } from './utils.js';
@@ -12,7 +12,7 @@ import { MINOR_FACTION_TYPES } from './minor-factions.js';
 import { drawResourceIcon } from './resource-icons.js';
 
 // ============================================
-// SPRITE ANIMATION — idle frame cycling
+// SPRITE ANIMATION — idle frame cyclig
 // ============================================
 const SPRITE_ANIM_FRAME_COUNT = 8;
 const SPRITE_ANIM_FRAME_MS = 150; // milliseconds per frame (~5.3 FPS idle bob)
@@ -114,19 +114,6 @@ function drawCapitalStar(cx, sx, sy, color) {
 // TERRAIN-AWARE IMPROVEMENT RENDERING
 // ============================================
 
-// Offscreen canvas for terrain-tinted improvement compositing
-let _impCanvas = null;
-let _impCtx = null;
-function getImpCanvas() {
-  if (!_impCanvas) {
-    _impCanvas = document.createElement('canvas');
-    _impCanvas.width = 128;
-    _impCanvas.height = 128;
-    _impCtx = _impCanvas.getContext('2d');
-  }
-  return { cv: _impCanvas, cx: _impCtx };
-}
-
 // Per-improvement layout: how big relative to hex, and vertical offset
 // Positive dy = lower in hex. Scale is fraction of HEX_SIZE*2
 const IMP_LAYOUT = {
@@ -140,15 +127,12 @@ const IMP_LAYOUT = {
   lumber_mill:   { scale: 0.70, dy:  0.00, dx: 0 },
 };
 
-// Tint strength per terrain — how much the terrain colour shifts the sprite
-const TINT_STRENGTH = 0.35;
-
 // Simple deterministic hash from tile coordinates — stable per tile, no flicker
 function tileHash(col, row) {
   return ((col * 7919) + (row * 104729)) & 0xFFFF;
 }
 
-// Draw a terrain-tinted, contextually-positioned improvement sprite
+// Draw a contextually-positioned improvement sprite with terrain colour tint overlay
 function drawTintedImprovement(mainCtx, impImg, tile, sx, sy, col, row) {
   const layout = IMP_LAYOUT[tile.improvement] || { scale: 0.65, dy: 0, dx: 0 };
   const spriteSize = HEX_SIZE * 2 * layout.scale;
@@ -156,69 +140,20 @@ function drawTintedImprovement(mainCtx, impImg, tile, sx, sy, col, row) {
   // Deterministic mirror based on tile position (~50% of tiles get flipped)
   const mirror = (tileHash(col, row) % 2) === 0;
 
-  // Get terrain base colour for tinting
-  const terrainKey = tile.feature || tile.base;
-  const tintRGB = BASE_COLORS[terrainKey] || BASE_COLORS[tile.base];
-
   // Position offset within the hex (flip dx when mirrored)
   const ox = sx + (mirror ? -layout.dx : layout.dx) * HEX_SIZE;
   const oy = sy + layout.dy * HEX_SIZE;
 
-  if (!tintRGB) {
-    // Fallback: no tinting, just draw smaller + positioned (still mirror)
-    mainCtx.save();
-    mainCtx.globalAlpha = 0.8;
-    if (mirror) {
-      mainCtx.translate(ox, oy);
-      mainCtx.scale(-1, 1);
-      mainCtx.drawImage(impImg, -spriteSize/2, -spriteSize/2, spriteSize, spriteSize);
-    } else {
-      mainCtx.drawImage(impImg, ox - spriteSize/2, oy - spriteSize/2, spriteSize, spriteSize);
-    }
-    mainCtx.globalAlpha = 1.0;
-    mainCtx.restore();
-    return;
-  }
-
-  // Composite on offscreen canvas: sprite × terrain colour
-  const { cv, cx } = getImpCanvas();
-  const cSize = cv.width;
-
-  // 1) Clear
-  cx.clearRect(0, 0, cSize, cSize);
-
-  // 2) Draw the improvement sprite (mirror on the offscreen canvas if needed)
-  cx.globalCompositeOperation = 'source-over';
-  if (mirror) {
-    cx.save(); cx.translate(cSize, 0); cx.scale(-1, 1);
-    cx.drawImage(impImg, 0, 0, cSize, cSize); cx.restore();
-  } else {
-    cx.drawImage(impImg, 0, 0, cSize, cSize);
-  }
-
-  // 3) Multiply-blend with terrain colour
-  cx.globalCompositeOperation = 'multiply';
-  const r = Math.round(tintRGB[0] + (255 - tintRGB[0]) * (1 - TINT_STRENGTH));
-  const g = Math.round(tintRGB[1] + (255 - tintRGB[1]) * (1 - TINT_STRENGTH));
-  const b = Math.round(tintRGB[2] + (255 - tintRGB[2]) * (1 - TINT_STRENGTH));
-  cx.fillStyle = `rgb(${r},${g},${b})`;
-  cx.fillRect(0, 0, cSize, cSize);
-
-  // 4) Restore alpha from original sprite (multiply kills transparency)
-  cx.globalCompositeOperation = 'destination-in';
-  if (mirror) {
-    cx.save(); cx.translate(cSize, 0); cx.scale(-1, 1);
-    cx.drawImage(impImg, 0, 0, cSize, cSize); cx.restore();
-  } else {
-    cx.drawImage(impImg, 0, 0, cSize, cSize);
-  }
-  cx.globalCompositeOperation = 'source-over';
-
-  // 5) Draw the tinted result onto the main canvas
+  // Draw the improvement sprite directly onto the main canvas
   mainCtx.save();
-  mainCtx.globalAlpha = 0.82;
-  mainCtx.drawImage(cv, ox - spriteSize/2, oy - spriteSize/2, spriteSize, spriteSize);
-  mainCtx.globalAlpha = 1.0;
+  mainCtx.globalAlpha = 0.85;
+  if (mirror) {
+    mainCtx.translate(ox, oy);
+    mainCtx.scale(-1, 1);
+    mainCtx.drawImage(impImg, -spriteSize / 2, -spriteSize / 2, spriteSize, spriteSize);
+  } else {
+    mainCtx.drawImage(impImg, ox - spriteSize / 2, oy - spriteSize / 2, spriteSize, spriteSize);
+  }
   mainCtx.restore();
 }
 
@@ -228,8 +163,8 @@ function drawRoadConnections(mainCtx, tile, c, r, sx, sy, camOffX, camOffY) {
   let hasConnection = false;
 
   mainCtx.save();
-  mainCtx.strokeStyle = 'rgba(140,115,70,0.55)';
-  mainCtx.lineWidth = HEX_SIZE * 0.14;
+  mainCtx.strokeStyle = 'rgba(160,130,75,0.7)';
+  mainCtx.lineWidth = HEX_SIZE * 0.16;
   mainCtx.lineCap = 'round';
 
   for (const n of neighbors) {
@@ -252,9 +187,9 @@ function drawRoadConnections(mainCtx, tile, c, r, sx, sy, camOffX, camOffY) {
   }
 
   if (!hasConnection) {
-    mainCtx.fillStyle = 'rgba(140,115,70,0.4)';
+    mainCtx.fillStyle = 'rgba(160,130,75,0.55)';
     mainCtx.beginPath();
-    mainCtx.arc(sx, sy, HEX_SIZE * 0.12, 0, Math.PI * 2);
+    mainCtx.arc(sx, sy, HEX_SIZE * 0.15, 0, Math.PI * 2);
     mainCtx.fill();
   }
 

--- a/src/units.js
+++ b/src/units.js
@@ -33,10 +33,11 @@ function isCivilian(unit) {
 }
 
 /** Returns true if the moving unit can stack on a tile that already has `existing` on it.
- *  Rule: one military + one civilian of the same owner may share a tile. */
+ *  Rule: one military + one non-combat unit (civilian or great_person) of the same owner may share a tile. */
 function canStackWith(movingUnit, existingUnit) {
   if (movingUnit.owner !== existingUnit.owner) return false;       // must be same owner
-  if (isCivilian(movingUnit) === isCivilian(existingUnit)) return false; // can't stack two of same class
+  const isNonCombat = (u) => ZOC_EXEMPT_CLASSES.includes(UNIT_TYPES[u.type]?.class);
+  if (isNonCombat(movingUnit) === isNonCombat(existingUnit)) return false; // can't stack two of same class
   return true;
 }
 
@@ -1035,6 +1036,38 @@ function detachFromArmy(generalId, armyIdx) {
   return true;
 }
 
+/** Release all army units back onto the map when a general dies.
+ *  Each unit is placed on the general's tile or the nearest passable adjacent tile. */
+function releaseGeneralArmy(general) {
+  if (!general.army || general.army.length === 0) return;
+  for (const stored of general.army) {
+    const ut = UNIT_TYPES[stored.type];
+    if (!ut) continue;
+    const candidates = [{ col: general.col, row: general.row }, ...getHexNeighbors(general.col, general.row)];
+    let spawnTile = null;
+    for (const tile of candidates) {
+      const t = game.map[tile.row]?.[tile.col];
+      if (!t || !isTilePassable(t)) continue;
+      const occupied = game.units.filter(u => u.col === tile.col && u.row === tile.row);
+      if (occupied.length >= 2) continue;
+      if (occupied.length === 1 && !canStackWith({ owner: general.owner, type: stored.type }, occupied[0])) continue;
+      spawnTile = tile;
+      break;
+    }
+    if (!spawnTile) spawnTile = { col: general.col, row: general.row }; // fallback
+    const newUnit = createUnit(stored.type, spawnTile.col, spawnTile.row, general.owner);
+    newUnit.id = stored.id;
+    newUnit.hp = stored.hp;
+    newUnit.xp = stored.xp || 0;
+    newUnit.combat = stored.combat;
+    newUnit.promotions = stored.promotions || [];
+    newUnit.level = stored.level || 1;
+    newUnit.moveLeft = 0;
+    game.units.push(newUnit);
+  }
+  general.army = [];
+}
+
 /** Move the general and all army units together */
 function moveArmyTo(general, col, row, callback) {
   // Standard movement — the general moves, army travels with it
@@ -1151,5 +1184,6 @@ export {
   getGeneralCapacity,
   attachToArmy,
   detachFromArmy,
+  releaseGeneralArmy,
   coordinatedAttack,
 };

--- a/tests/great-general.test.js
+++ b/tests/great-general.test.js
@@ -1,5 +1,7 @@
 import { describe, test, expect, beforeEach } from 'vitest';
-import { attachToArmy, detachFromArmy, coordinatedAttack, getGeneralCapacity } from '../src/units.js';
+import { attachToArmy, detachFromArmy, coordinatedAttack, getGeneralCapacity, releaseGeneralArmy } from '../src/units.js';
+import { processZOCCaptures, resolveCombat } from '../src/combat.js';
+import { isInEnemyZOC } from '../src/units.js';
 import { setupGameState, makeUnit } from './fixtures.js';
 
 describe('Great General — Army Mechanics', () => {
@@ -151,5 +153,120 @@ describe('Great General — Army Mechanics', () => {
 
       expect(result).toBe(false);
     });
+  });
+});
+
+describe('Great General — ZOC and class', () => {
+  let state;
+
+  beforeEach(() => {
+    state = setupGameState();
+  });
+
+  function makeGeneral(overrides = {}) {
+    return makeUnit({
+      id: 100, type: 'great_general', col: 5, row: 5, owner: 'player',
+      combat: 0, moveLeft: 3, army: [], armyCapacity: 3, xp: 0,
+      ...overrides,
+    });
+  }
+
+  test('Great General should not project ZOC', () => {
+    const general = makeGeneral({ owner: 'faction_a', col: 10, row: 10 });
+    state.units = [general];
+
+    // A unit adjacent to an enemy Great General should NOT be in ZOC
+    expect(isInEnemyZOC(11, 10, 'player')).toBe(false);
+  });
+
+  test('Great General should not be captured in ZOC even during war', () => {
+    const general = makeGeneral({ col: 10, row: 10, owner: 'player' });
+    const enemyWarrior = makeUnit({ id: 2, col: 11, row: 10, type: 'warrior', owner: 'faction_a' });
+    state.units = [general, enemyWarrior];
+    state.wars = [{ attacker: 'player', defender: 'faction_a' }];
+
+    processZOCCaptures();
+
+    // Great General should still be on the map, not captured or killed
+    expect(state.units.find(u => u.id === 100)).toBeDefined();
+  });
+
+  test('Great General with attached units should survive ZOC (units not lost)', () => {
+    const general = makeGeneral({
+      col: 10, row: 10, owner: 'player',
+      army: [{ id: 10, type: 'warrior', hp: 100, xp: 0, combat: 20, promotions: [], level: 1 }],
+    });
+    const enemyWarrior = makeUnit({ id: 2, col: 11, row: 10, type: 'warrior', owner: 'faction_a' });
+    state.units = [general, enemyWarrior];
+    state.wars = [{ attacker: 'player', defender: 'faction_a' }];
+
+    processZOCCaptures();
+
+    const survivingGeneral = state.units.find(u => u.id === 100);
+    expect(survivingGeneral).toBeDefined();
+    expect(survivingGeneral.army).toHaveLength(1);
+  });
+});
+
+describe('releaseGeneralArmy()', () => {
+  let state;
+
+  beforeEach(() => {
+    state = setupGameState();
+  });
+
+  function makeGeneral(overrides = {}) {
+    return makeUnit({
+      id: 100, type: 'great_general', col: 5, row: 5, owner: 'player',
+      combat: 0, moveLeft: 3, army: [], armyCapacity: 3, xp: 0,
+      ...overrides,
+    });
+  }
+
+  test('should release attached army units back onto the map', () => {
+    const general = makeGeneral({
+      army: [
+        { id: 10, type: 'warrior', hp: 80, xp: 5, combat: 20, promotions: [], level: 1 },
+        { id: 11, type: 'archer', hp: 60, xp: 2, combat: 15, promotions: [], level: 1 },
+      ],
+    });
+    state.units = [general];
+
+    releaseGeneralArmy(general);
+
+    expect(state.units.find(u => u.id === 10)).toBeDefined();
+    expect(state.units.find(u => u.id === 11)).toBeDefined();
+    expect(general.army).toHaveLength(0);
+  });
+
+  test('should preserve HP and XP of released units', () => {
+    const general = makeGeneral({
+      army: [{ id: 10, type: 'warrior', hp: 75, xp: 12, combat: 20, promotions: [], level: 2 }],
+    });
+    state.units = [general];
+
+    releaseGeneralArmy(general);
+
+    const released = state.units.find(u => u.id === 10);
+    expect(released.hp).toBe(75);
+    expect(released.xp).toBe(12);
+    expect(released.level).toBe(2);
+  });
+
+  test('should release army units when Great General is killed in combat', () => {
+    const attacker = makeUnit({ id: 1, col: 5, row: 6, type: 'warrior', owner: 'faction_a', hp: 100 });
+    const general = makeGeneral({
+      col: 5, row: 5, owner: 'player', hp: 1,
+      army: [{ id: 10, type: 'warrior', hp: 100, xp: 0, combat: 20, promotions: [], level: 1 }],
+    });
+    state.units = [attacker, general];
+    state.cities = [];
+
+    const result = resolveCombat(attacker, general);
+
+    expect(result.defenderDied).toBe(true);
+    expect(state.units.find(u => u.id === 100)).toBeUndefined();
+    // Army unit should be released, not lost
+    expect(state.units.find(u => u.id === 10)).toBeDefined();
   });
 });


### PR DESCRIPTION
Staging-tested batch of fixes from devel:

- **Fix improvement rendering** (#412): Replaced broken offscreen canvas compositing (multiply + destination-in) with simple direct sprite draw. Farms, roads, plantations etc now render correctly.
- - **Fix map disappearing** (#408): Pre-compute territory ownership cache to prevent map blanking.
- - **Fix Great Generals** (#409): Generals captured/killed in ZOC no longer lose attached army bonuses.
- - Road visibility boost (opacity 0.55→0.7, width 0.14→0.16)
All verified on staging.uncivilized.fun.