### PR TITLE
fix: diplomacy multi-action, at-war label, blocking war alerts, barbarian camp UX

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -1009,7 +1009,8 @@ DIPLOMACY DEPTH RULES:
 - You have family members you can name: create realistic names fitting your culture
 - React emotionally to betrayals, broken promises, and surprise attacks
 - Consider the balance of power: if the player is much stronger, be more accommodating; if weaker, be bolder
-- Only include an action tag when you genuinely want to propose something. Casual conversation needs no action tag."""
+- Only include an action tag when you genuinely want to propose something. Casual conversation needs no action tag.
+- MULTIPLE COMMITMENTS: if the player asks you to do SEVERAL things and you agree to all of them (e.g. "let's form an alliance AND attack shadow_kael together"), emit ONE action tag for EACH commitment — do NOT merge them or drop one. Example: '[ACTION: {{"type": "offer_alliance", "duration": 15}}] [ACTION: {{"type": "wage_war_on", "target_faction": "shadow_kael", "duration": 15}}]'. Every commitment you make in words MUST have a matching action tag, otherwise the game will not carry it out."""
 
     # Build conversation messages — cap each history entry to 500 chars
     # to prevent token-stuffing attacks via bloated conversation_history
@@ -1045,16 +1046,17 @@ DIPLOMACY DEPTH RULES:
         )
         reply = response.content[0].text
 
-        # Parse action from response — robust extraction
-        action = None
-        action_match = re.search(r'\[ACTION:\s*(\{.*?\})\s*\]', reply, re.DOTALL)
-        if action_match:
+        # Parse actions from response — support MULTIPLE [ACTION: ...] tags so the AI
+        # can commit to several things at once (e.g., offer_alliance + wage_war_on
+        # when the player asks for an alliance AND a joint attack on a common enemy).
+        actions = []
+        for m in re.finditer(r'\[ACTION:\s*(\{.*?\})\s*\]', reply, re.DOTALL):
             try:
-                action = json.loads(action_match.group(1))
-                reply = reply[:action_match.start()].strip()
+                actions.append(json.loads(m.group(1)))
             except json.JSONDecodeError:
-                action = None
-        # Also strip partial ACTION tags that didn't fully close
+                pass
+        # Strip all ACTION tags from the reply text (complete and partial)
+        reply = re.sub(r'\[ACTION:\s*\{.*?\}\s*\]', '', reply, flags=re.DOTALL).strip()
         if '[ACTION:' in reply:
             reply = reply[:reply.index('[ACTION:')].strip()
 
@@ -1063,18 +1065,39 @@ DIPLOMACY DEPTH RULES:
         # made a mistake (it should use 'wage_war_on' to attack a third party, or
         # 'surprise_attack' for a treacherous betrayal). Sanitize to 'none' to
         # prevent erroneously breaking the alliance.
-        if action and action.get('type') == 'declare_war':
-            active_alliances = (msg.game_state or {}).get('alliances', {})
-            if active_alliances.get(msg.character_id):
-                action = {'type': 'none'}
+        active_alliances = (msg.game_state or {}).get('alliances', {})
+        for i, act in enumerate(actions):
+            if act.get('type') == 'declare_war' and active_alliances.get(msg.character_id):
+                actions[i] = {'type': 'none'}
 
         # Fallback: if the player offered gold and the AI emitted an agreement
         # without gold_cost, inject the amount from the player's message
         AGREEMENT_TYPES = {'mutual_defense', 'offer_alliance', 'open_borders', 'non_aggression', 'ceasefire', 'tech_share', 'offer_peace'}
-        if action and action.get('type') in AGREEMENT_TYPES and not action.get('gold_cost'):
-            gold_match = re.search(r'(\d+)\s*gold', msg.message, re.IGNORECASE)
-            if gold_match:
-                action['gold_cost'] = int(gold_match.group(1))
+        gold_match = re.search(r'(\d+)\s*gold', msg.message, re.IGNORECASE)
+        for act in actions:
+            if act.get('type') in AGREEMENT_TYPES and not act.get('gold_cost') and gold_match:
+                act['gold_cost'] = int(gold_match.group(1))
+
+        # Select the PRIMARY action for backward compatibility. When the AI commits
+        # to multiple things (e.g., alliance + joint attack on a third party), prefer
+        # the concrete war/commitment action so the most consequential promise is the
+        # one that gets executed by frontends that only read `action` (singular).
+        PRIMARY_PRIORITY = [
+            'wage_war_on', 'surprise_attack', 'declare_war', 'make_peace_with',
+            'gift_city', 'demand_city', 'defend_city', 'attack_target',
+            'tribute_payment', 'game_mod',
+            'offer_alliance', 'mutual_defense', 'non_aggression', 'ceasefire',
+            'open_borders', 'tech_share', 'joint_research', 'offer_peace',
+            'marriage_offer', 'trade_deal', 'resource_trade', 'offer_trade',
+            'demand_tribute', 'accept_tribute', 'send_gift', 'threaten',
+            'embargo', 'vassalage', 'introduce', 'share_intel',
+            'respect_borders', 'no_settle_near',
+        ]
+        def _priority(act):
+            t = act.get('type', '') if isinstance(act, dict) else ''
+            return PRIMARY_PRIORITY.index(t) if t in PRIMARY_PRIORITY else len(PRIMARY_PRIORITY)
+        sorted_actions = sorted(actions, key=_priority) if actions else []
+        action = sorted_actions[0] if sorted_actions else None
 
         # Log diplomacy interaction to Supabase (visitor_id already extracted above)
         _log_diplomacy_interaction(
@@ -1089,6 +1112,7 @@ DIPLOMACY DEPTH RULES:
         return {
             "reply": reply,
             "action": action,
+            "actions": sorted_actions,
             "character": profile["name"],
             "character_type": profile["type"],
         }

--- a/server.py
+++ b/server.py
@@ -783,7 +783,8 @@ DIPLOMACY DEPTH RULES:
 - You have family members you can name: create realistic names fitting your culture
 - React emotionally to betrayals, broken promises, and surprise attacks
 - Consider the balance of power: if the player is much stronger, be more accommodating; if weaker, be bolder
-- Only include an action tag when you genuinely want to propose something. Casual conversation needs no action tag."""
+- Only include an action tag when you genuinely want to propose something. Casual conversation needs no action tag.
+- MULTIPLE COMMITMENTS: if the player asks you to do SEVERAL things and you agree to all of them (e.g. "let's form an alliance AND attack shadow_kael together"), emit ONE action tag for EACH commitment — do NOT merge them or drop one. Example: '[ACTION: {{"type": "offer_alliance", "duration": 15}}] [ACTION: {{"type": "wage_war_on", "target_faction": "shadow_kael", "duration": 15}}]'. Every commitment you make in words MUST have a matching action tag, otherwise the game will not carry it out."""
 
     # Build conversation messages
     messages = []
@@ -806,16 +807,17 @@ DIPLOMACY DEPTH RULES:
         reply = response.content[0].text
         print(f"[CHAT] Got reply: {reply[:80]}...")
 
-        # Parse action from response — robust extraction
-        action = None
-        action_match = re.search(r'\[ACTION:\s*(\{.*?\})\s*\]', reply, re.DOTALL)
-        if action_match:
+        # Parse actions from response — support MULTIPLE [ACTION: ...] tags so the AI
+        # can commit to several things at once (e.g., offer_alliance + wage_war_on
+        # when the player asks for an alliance AND a joint attack on a common enemy).
+        actions = []
+        for m in re.finditer(r'\[ACTION:\s*(\{.*?\})\s*\]', reply, re.DOTALL):
             try:
-                action = json.loads(action_match.group(1))
-                reply = reply[:action_match.start()].strip()
+                actions.append(json.loads(m.group(1)))
             except json.JSONDecodeError:
-                action = None
-        # Also strip partial ACTION tags that didn't fully close
+                pass
+        # Strip all ACTION tags from the reply text (complete and partial)
+        reply = re.sub(r'\[ACTION:\s*\{.*?\}\s*\]', '', reply, flags=re.DOTALL).strip()
         if '[ACTION:' in reply:
             reply = reply[:reply.index('[ACTION:')].strip()
 
@@ -824,18 +826,39 @@ DIPLOMACY DEPTH RULES:
         # made a mistake (it should use 'wage_war_on' to attack a third party, or
         # 'surprise_attack' for a treacherous betrayal). Sanitize to 'none' to
         # prevent erroneously breaking the alliance.
-        if action and action.get('type') == 'declare_war':
-            active_alliances = (msg.game_state or {}).get('alliances', {})
-            if active_alliances.get(msg.character_id):
-                action = {'type': 'none'}
+        active_alliances = (msg.game_state or {}).get('alliances', {})
+        for i, act in enumerate(actions):
+            if act.get('type') == 'declare_war' and active_alliances.get(msg.character_id):
+                actions[i] = {'type': 'none'}
 
         # Fallback: if the player offered gold and the AI emitted an agreement
         # without gold_cost, inject the amount from the player's message
         AGREEMENT_TYPES = {'mutual_defense', 'offer_alliance', 'open_borders', 'non_aggression', 'ceasefire', 'tech_share', 'offer_peace'}
-        if action and action.get('type') in AGREEMENT_TYPES and not action.get('gold_cost'):
-            gold_match = re.search(r'(\d+)\s*gold', msg.message, re.IGNORECASE)
-            if gold_match:
-                action['gold_cost'] = int(gold_match.group(1))
+        gold_match = re.search(r'(\d+)\s*gold', msg.message, re.IGNORECASE)
+        for act in actions:
+            if act.get('type') in AGREEMENT_TYPES and not act.get('gold_cost') and gold_match:
+                act['gold_cost'] = int(gold_match.group(1))
+
+        # Select the PRIMARY action for backward compatibility. When the AI commits
+        # to multiple things (e.g., alliance + joint attack on a third party), prefer
+        # the concrete war/commitment action so the most consequential promise is the
+        # one that gets executed by frontends that only read `action` (singular).
+        PRIMARY_PRIORITY = [
+            'wage_war_on', 'surprise_attack', 'declare_war', 'make_peace_with',
+            'gift_city', 'demand_city', 'defend_city', 'attack_target',
+            'tribute_payment', 'game_mod',
+            'offer_alliance', 'mutual_defense', 'non_aggression', 'ceasefire',
+            'open_borders', 'tech_share', 'joint_research', 'offer_peace',
+            'marriage_offer', 'trade_deal', 'resource_trade', 'offer_trade',
+            'demand_tribute', 'accept_tribute', 'send_gift', 'threaten',
+            'embargo', 'vassalage', 'introduce', 'share_intel',
+            'respect_borders', 'no_settle_near',
+        ]
+        def _priority(act):
+            t = act.get('type', '') if isinstance(act, dict) else ''
+            return PRIMARY_PRIORITY.index(t) if t in PRIMARY_PRIORITY else len(PRIMARY_PRIORITY)
+        sorted_actions = sorted(actions, key=_priority) if actions else []
+        action = sorted_actions[0] if sorted_actions else None
 
         # Log diplomacy interaction to Supabase
         visitor_id = request.headers.get("x-visitor-id", "anonymous")
@@ -851,6 +874,7 @@ DIPLOMACY DEPTH RULES:
         return {
             "reply": reply,
             "action": action,
+            "actions": sorted_actions,
             "character": profile["name"],
             "character_type": profile["type"],
         }

--- a/src/ai-diplomacy.js
+++ b/src/ai-diplomacy.js
@@ -10,6 +10,7 @@ import { game } from './state.js';
 import { addEvent, logAction, showToast, showDiploToast } from './events.js';
 import { hexDistance } from './hex.js';
 import { hasResourceAccess } from './map.js';
+import { notifyAIWarDeclaration, queueAIWarOnPlayer } from './war-notifications.js';
 
 // ============================================
 // VISIBILITY LEVELS
@@ -220,6 +221,9 @@ function declareWar(a, b) {
   addEvent(msg, 'diplomacy');
   showDiploToast('War Declared', msg);
   logAction('diplomacy', msg, { type: 'ai_war', attacker: a, defender: b });
+
+  // If the war involves the player or a player ally, queue a blocking alert
+  notifyAIWarDeclaration(a, b, `${factionA.name} declared war on ${factionB.name}`);
 
   // Break any existing alliance or trade between them
   removeAlliance(a, b);
@@ -1057,6 +1061,7 @@ function checkMilitaryBorderPressure(factionIds) {
         game.relationships[fid] = Math.min(-50, (game.relationships[fid] || 0) - 30);
         addEvent(`${fName} has declared a pre-emptive war against you!`, 'combat');
         showDiploToast('War!', `${fName} launches a pre-emptive strike! Your border aggression pushed them too far.`);
+        queueAIWarOnPlayer(fid, `Pre-emptive war over border aggression`);
       }
     }
   }

--- a/src/diplomacy-api.js
+++ b/src/diplomacy-api.js
@@ -136,6 +136,23 @@ export function isDiplomacyLoaded() { return _pluginLoaded; }
 
 // Wrapper exports — these delegate to _plugin so that late registration works
 export function getRelationLabel(...args) { return _plugin.getRelationLabel(...args); }
+
+// War-aware relation label: when the player is at war with the faction, the
+// displayed label should be "At War" regardless of the underlying relationship
+// score. Base-game UI should call this instead of getRelationLabel() whenever
+// it has a factionId available.
+export function getWarAwareRelationLabel(factionId, value) {
+  if (factionId && factionId !== 'player') {
+    const wars = (game && game.aiWars) || [];
+    const atWar = wars.some(w =>
+      (w.attacker === 'player' && w.defender === factionId) ||
+      (w.attacker === factionId && w.defender === 'player')
+    );
+    if (atWar) return { text: 'At War', cls: 'relation-at-war' };
+  }
+  const rel = (value !== undefined) ? value : ((game && game.relationships && game.relationships[factionId]) || 0);
+  return getRelationLabel(rel);
+}
 export function establishTradeRoute(...args) {
   const result = _plugin.establishTradeRoute(...args);
   // Trigger currency eureka when a trade route is established

--- a/src/minor-factions.js
+++ b/src/minor-factions.js
@@ -214,12 +214,31 @@ function interactWithBarbarianCamp(campId) {
   if (convertReqs.length > 0) html += `<br><small style="color:#d9534f">Requires: ${convertReqs.join(', ')}</small>`;
   html += `</button>`;
 
-  // 6. Bribe to Attack — redirect barbarians to attack a specific opponent
-  const knownFactions = Object.keys(game.factionCities || {}).filter(fid => game.metFactions && game.metFactions[fid]);
+  // 6. Bribe to Attack — redirect barbarians at a specific opponent
+  // Only list factions that actually have cities or units within raiding range
+  // of THIS camp (10 hexes). Raiders can't strike at opponents halfway across
+  // the map, so don't offer those as targets.
+  const RAID_RANGE = 10;
+  const inRaidRange = (fid) => {
+    const fc = game.factionCities && game.factionCities[fid];
+    if (fc && hexDistance(fc.col, fc.row, bc.col, bc.row) <= RAID_RANGE) return true;
+    const exCities = (game.aiFactionCities && game.aiFactionCities[fid]) || [];
+    for (const c of exCities) {
+      if (hexDistance(c.col, c.row, bc.col, bc.row) <= RAID_RANGE) return true;
+    }
+    const units = (game.units || []).filter(u => u.owner === fid);
+    for (const u of units) {
+      if (hexDistance(u.col, u.row, bc.col, bc.row) <= RAID_RANGE) return true;
+    }
+    return false;
+  };
+  const knownFactions = Object.keys(game.factionCities || {})
+    .filter(fid => game.metFactions && game.metFactions[fid])
+    .filter(inRaidRange);
   if (knownFactions.length > 0 && !bc.pacified) {
     const bribeCost = 40 + Math.floor(bc.strength * 2);
     const currentTarget = bc.bribeTarget || null;
-    html += `<p style="color:#d9534f;margin-top:8px;font-size:11px;font-weight:600">Direct Raids Against:</p>`;
+    html += `<p style="color:#d9534f;margin-top:8px;font-size:11px;font-weight:600">Direct Raids Against (within ${RAID_RANGE} hexes):</p>`;
     for (const fid of knownFactions) {
       const fn = FACTIONS[fid] ? FACTIONS[fid].name : fid;
       const fc = FACTIONS[fid] ? FACTIONS[fid].color : '#888';
@@ -229,14 +248,32 @@ function interactWithBarbarianCamp(campId) {
     }
   }
 
-  // 7. Raid / Attack — direct combat or instant destroy if unit is on camp
-  const unitOnCamp = game.units.find(u => u.owner === 'player' && u.col === bc.col && u.row === bc.row && UNIT_TYPES[u.type]?.combat > 0);
+  // 7. Raid / Attack — previously "Destroy Camp" (instant) only appeared when
+  // a unit was sat ON the camp, while "Attack Camp" (combat) only appeared
+  // when adjacent. Make both options equally available: the combat-attack
+  // option works from on-tile or adjacent, and the instant-destroy option
+  // requires a unit standing on the camp.
+  const unitOnCamp = game.units.find(u =>
+    u.owner === 'player' &&
+    u.col === bc.col && u.row === bc.row &&
+    UNIT_TYPES[u.type]?.combat > 0
+  );
+  const unitInRange = unitOnCamp || game.units.find(u =>
+    u.owner === 'player' &&
+    UNIT_TYPES[u.type]?.combat > 0 &&
+    hexDistance(u.col, u.row, bc.col, bc.row) === 1
+  );
+  if (unitInRange) {
+    html += `<button class="minor-btn minor-btn-danger" onclick="barbCampAction('${campId}','attack')">`;
+    html += `\u{2694}\u{FE0F} Attack Camp — Engage in combat</button>`;
+  }
   if (unitOnCamp) {
     html += `<button class="minor-btn minor-btn-danger" onclick="barbCampAction('${campId}','destroy_camp')">`;
     html += `\u{1F525} Destroy Camp — Raze and loot (+100g)</button>`;
-  } else {
-    html += `<button class="minor-btn minor-btn-danger" onclick="barbCampAction('${campId}','attack')">`;
-    html += `\u{1F525} Attack Camp — Destroy and loot (need adjacent unit)</button>`;
+  }
+  if (!unitInRange) {
+    html += `<button class="minor-btn minor-btn-danger" disabled style="opacity:0.5">`;
+    html += `\u{1F525} Attack Camp — Need a combat unit on or adjacent to the camp</button>`;
   }
 
   html += '</div>';
@@ -404,7 +441,15 @@ window.barbCampAction = function(campId, action) {
       break;
     }
     case 'destroy_camp': {
-      // Instant destroy — unit is standing on the camp
+      // Instant destroy — requires a combat unit standing ON the camp
+      const unitOnCamp = game.units.find(u =>
+        u.owner === 'player' && u.col === bc.col && u.row === bc.row &&
+        UNIT_TYPES[u.type]?.combat > 0
+      );
+      if (!unitOnCamp) {
+        addEvent('You need a combat unit standing on the camp to raze it.', 'combat');
+        return;
+      }
       bc.destroyed = true;
       const lootGold = 100;
       game.gold += lootGold;

--- a/src/render.js
+++ b/src/render.js
@@ -7,7 +7,7 @@ import { getTileYields, getTileName, getTileMoveCost, isResourceRevealed, crosse
 import { computeMoveRange, computeRiverCrossings, computeAttackRange, getEnemyZOCHexes } from './units.js';
 import { getUnitAt, getCityAt } from './combat.js';
 import { getWaypointPath } from './improvements.js';
-import { getRelationLabel } from './diplomacy-api.js';
+import { getRelationLabel, getWarAwareRelationLabel } from './diplomacy-api.js';
 import { MINOR_FACTION_TYPES } from './minor-factions.js';
 import { drawResourceIcon } from './resource-icons.js';
 
@@ -1490,8 +1490,8 @@ function drawHoverTooltip(ctx, hexScreenX, hexScreenY, col, row, camX, camY) {
         lines.push({ text: cityHere.owner === 'barbarian' ? 'Barbarian Camp' : (met ? faction.name : 'Unknown Civilization'), color: '#aab0a8' });
         if (met) {
           const rel = game.relationships[cityHere.owner] || 0;
-          const relLabel = getRelationLabel(rel);
-          lines.push({ text: `${relLabel.text} (${rel > 0 ? '+' : ''}${rel})`, color: relLabel.cls === 'relation-hostile' ? '#d9534f' : relLabel.cls === 'relation-friendly' ? '#6aab5c' : relLabel.cls === 'relation-allied' ? '#c9a84c' : '#aab0a8' });
+          const relLabel = getWarAwareRelationLabel(cityHere.owner, rel);
+          lines.push({ text: `${relLabel.text} (${rel > 0 ? '+' : ''}${rel})`, color: (relLabel.cls === 'relation-hostile' || relLabel.cls === 'relation-at-war') ? '#d9534f' : relLabel.cls === 'relation-friendly' ? '#6aab5c' : relLabel.cls === 'relation-allied' ? '#c9a84c' : '#aab0a8' });
         }
       }
     }

--- a/src/turn.js
+++ b/src/turn.js
@@ -18,6 +18,7 @@ import { getUnitAt, processZOCCaptures, barbarianRazeAICity, resolveCombat, isAt
 import { decayReputation, detectContradictions, updateReputation, ensureReputationState } from './reputation.js';
 import { createUnit, selectUnit, autoSelectNext, isTerritoryBlocked, getTileOwner } from './units.js';
 import { autoSave } from './save-load.js';
+import { notifyAIWarDeclaration, processPendingWarAlerts } from './war-notifications.js';
 import { clampCamera } from './input.js';
 import { processAIDiplomacy, resetTurnActions, processAITradeIncome } from './ai-diplomacy.js';
 import { calculateCityHousing, getHousingGrowthModifier } from './housing.js';
@@ -469,6 +470,11 @@ function endTurn() {
     processAIDiplomacy();
     processAITradeIncome();
   } catch (e) { console.error('Error in AI diplomacy:', e); }
+
+  // --- Blocking war notifications (must run before player regains control) ---
+  try {
+    processPendingWarAlerts();
+  } catch (e) { console.error('Error processing war alerts:', e); }
 
   // --- Eject any units trespassing after diplomacy changes (peace, expired borders) ---
   // NOTE: A second, final ejection pass runs later (after AI unit spawning)
@@ -1819,6 +1825,7 @@ function processAIMilitaryTurns() {
         const aName = FACTIONS[commit.factionId]?.name || commit.factionId;
         const bName = FACTIONS[commit.target]?.name || commit.target;
         addEvent(`${aName} has declared war on ${bName}!`, 'diplomacy');
+        notifyAIWarDeclaration(commit.factionId, commit.target, `Commitment fulfilled: ${aName} declared war on ${bName}`);
       }
     }
   }

--- a/src/ui-panels.js
+++ b/src/ui-panels.js
@@ -6,7 +6,7 @@ import { getTileYields, getTileName, isResourceRevealed, hasResourceAccess } fro
 import { render } from './render.js';
 import { addEvent, logAction, showToast, showCompletionNotification } from './events.js';
 import { selectUnit, deselectUnit, applyPromotion, upgradeUnit, selectNextUnit, moveUnitTo } from './units.js';
-import { getRelationLabel } from './diplomacy-api.js';
+import { getRelationLabel, getWarAwareRelationLabel } from './diplomacy-api.js';
 import { getModCombatBonus } from './diplomacy-api.js';
 import { isAtWarWith, declareSurpriseWar, confirmAndDeclareWar } from './combat.js';
 import { showWorkerActions, showSettlerActions } from './improvements.js';
@@ -197,7 +197,7 @@ function showSelectionPanel(unit) {
     const fName = faction ? faction.name : unit.owner;
     const fColor = faction ? faction.color : '#888';
     const rel = game.relationships[unit.owner] || 0;
-    const relLabel = getRelationLabel(rel);
+    const relLabel = getWarAwareRelationLabel(unit.owner, rel);
 
     html += `<div class="sel-header">
       <div class="sel-icon" style="background:${hexToRgba(fColor, 0.2)};border-color:${fColor}">${ut.icon}</div>
@@ -454,7 +454,7 @@ function showCityPanel(cityData) {
     const fName = faction ? faction.name : cityData.owner;
     const fColor = faction ? faction.color : '#888';
     const rel = game.relationships[cityData.owner] || 0;
-    const relLabel = getRelationLabel(rel);
+    const relLabel = getWarAwareRelationLabel(cityData.owner, rel);
 
     title = `\u{1F3F0} ${cityData.name}`;
     body = `<p style="color:${fColor}">${fName}</p>`;

--- a/src/war-notifications.js
+++ b/src/war-notifications.js
@@ -1,0 +1,165 @@
+// ============================================
+// WAR NOTIFICATIONS
+// ============================================
+// Blocking notifications when AI factions declare war on the player,
+// and decision dialogs when AI factions attack the player's allies.
+
+import { game } from './state.js';
+import { FACTIONS } from './constants.js';
+import { addEvent, logAction, showToast } from './events.js';
+
+// ----- Queues live on game state so they survive save/load -----
+function ensureQueues() {
+  if (!game.pendingWarAlerts) game.pendingWarAlerts = [];
+  if (!game.pendingAllyDecisions) game.pendingAllyDecisions = [];
+}
+
+// Call this when an AI faction has just declared war on the player.
+// Queues a blocking alert that the player must dismiss before taking actions.
+export function queueAIWarOnPlayer(factionId, reason) {
+  if (!factionId || factionId === 'player') return;
+  ensureQueues();
+  // Avoid duplicate entries for the same attacker
+  if (game.pendingWarAlerts.some(a => a.factionId === factionId)) return;
+  game.pendingWarAlerts.push({
+    factionId,
+    reason: reason || 'declared war',
+    turn: game.turn,
+  });
+}
+
+// Call this when an AI faction has just declared war on a faction the player
+// is allied with. Player must choose to defend (declare war on attacker) or
+// cancel the alliance.
+export function queueAllyAttacked(attackerId, allyId) {
+  if (!attackerId || !allyId) return;
+  if (attackerId === 'player' || allyId === 'player') return;
+  ensureQueues();
+  // Dedupe — one decision per (attacker, ally) pair
+  if (game.pendingAllyDecisions.some(a => a.attackerId === attackerId && a.allyId === allyId)) return;
+  game.pendingAllyDecisions.push({
+    attackerId,
+    allyId,
+    turn: game.turn,
+  });
+}
+
+// True if there's a blocking alert outstanding — input handlers should refuse
+// to act on the game until this is drained.
+export function hasBlockingAlert() {
+  ensureQueues();
+  return game.pendingWarAlerts.length > 0 || game.pendingAllyDecisions.length > 0;
+}
+
+// Drain the queues by showing blocking dialogs one at a time.
+// Called at the end of endTurn() after AI processing, and also at game load
+// to catch any alerts that were persisted mid-turn.
+export function processPendingWarAlerts() {
+  ensureQueues();
+
+  // 1. AI-declared wars on the player — blocking alert()
+  while (game.pendingWarAlerts.length > 0) {
+    const entry = game.pendingWarAlerts.shift();
+    const faction = FACTIONS[entry.factionId];
+    const name = faction ? faction.name : entry.factionId;
+    const message = `\u26A0 WAR DECLARED\n\n${name} has declared war on you!\n\n` +
+      (entry.reason ? `Reason: ${entry.reason}\n\n` : '') +
+      `You are now at war. Prepare your defences.`;
+    try {
+      if (typeof alert === 'function') alert(message);
+    } catch (_) { /* non-browser env */ }
+    addEvent(`${name} has declared war on you!`, 'combat');
+    logAction('diplomacy', `AI declared war on player: ${name}`, { type: 'ai_war_on_player', factionId: entry.factionId });
+  }
+
+  // 2. AI attacks on player's allies — confirm() dialog with defend/cancel choice
+  while (game.pendingAllyDecisions.length > 0) {
+    const entry = game.pendingAllyDecisions.shift();
+    const attacker = FACTIONS[entry.attackerId];
+    const ally = FACTIONS[entry.allyId];
+    const attackerName = attacker ? attacker.name : entry.attackerId;
+    const allyName = ally ? ally.name : entry.allyId;
+
+    const message = `\u26A0 YOUR ALLY IS UNDER ATTACK\n\n` +
+      `${attackerName} has declared war on your ally ${allyName}.\n\n` +
+      `OK = Defend ${allyName} (declare war on ${attackerName})\n` +
+      `Cancel = Abandon your alliance with ${allyName}`;
+    let defend = false;
+    try {
+      if (typeof confirm === 'function') defend = confirm(message);
+    } catch (_) { /* non-browser env */ }
+
+    if (defend) {
+      // Declare war on attacker
+      if (!game.aiWars) game.aiWars = [];
+      const already = game.aiWars.some(w =>
+        (w.attacker === 'player' && w.defender === entry.attackerId) ||
+        (w.attacker === entry.attackerId && w.defender === 'player')
+      );
+      if (!already) {
+        game.aiWars.push({
+          attacker: 'player', defender: entry.attackerId,
+          startTurn: game.turn, turnsActive: 0,
+        });
+      }
+      // Break peace agreements with the attacker
+      if (game.nonAggressionPacts) delete game.nonAggressionPacts[entry.attackerId];
+      if (game.ceasefires) delete game.ceasefires[entry.attackerId];
+      if (game.relationships) {
+        game.relationships[entry.attackerId] = Math.min(-50, (game.relationships[entry.attackerId] || 0) - 30);
+      }
+      addEvent(`You honoured your alliance with ${allyName} and declared war on ${attackerName}!`, 'diplomacy');
+      showToast('Alliance Honoured', `War declared on ${attackerName}`, 5000);
+      logAction('diplomacy', `Player defended ally: declared war on ${attackerName}`, {
+        type: 'player_defend_ally', attacker: entry.attackerId, ally: entry.allyId,
+      });
+    } else {
+      // Abandon alliance with ally
+      if (game.activeAlliances) delete game.activeAlliances[entry.allyId];
+      if (game.defensePacts) delete game.defensePacts[entry.allyId];
+      // Also remove from aiAlliances
+      if (game.aiAlliances) {
+        game.aiAlliances = game.aiAlliances.filter(al =>
+          !(al.factions.includes('player') && al.factions.includes(entry.allyId))
+        );
+      }
+      if (game.relationships) {
+        game.relationships[entry.allyId] = Math.min(game.relationships[entry.allyId] || 0, -20);
+      }
+      addEvent(`You abandoned your alliance with ${allyName}. Relations soured.`, 'diplomacy');
+      showToast('Alliance Abandoned', `${allyName} has been abandoned`, 5000);
+      logAction('diplomacy', `Player abandoned alliance with ${allyName}`, {
+        type: 'player_abandon_ally', ally: entry.allyId, attacker: entry.attackerId,
+      });
+    }
+  }
+}
+
+// Check if the given faction is an ally of the player. Used by war-creation
+// code paths to decide whether to queue an ally-attacked decision.
+export function isPlayerAlly(factionId) {
+  if (!factionId) return false;
+  if (game.activeAlliances && game.activeAlliances[factionId]) return true;
+  if (game.defensePacts && game.defensePacts[factionId]) return true;
+  if (game.aiAlliances) {
+    for (const al of game.aiAlliances) {
+      if (al.factions.includes('player') && al.factions.includes(factionId)) return true;
+    }
+  }
+  return false;
+}
+
+// Helper wrapper: when AI declares war on a faction, this function does the
+// right thing — queues a player-war alert OR an ally-attacked decision.
+// Returns true if player involvement was queued.
+export function notifyAIWarDeclaration(attackerId, defenderId, reason) {
+  if (defenderId === 'player') {
+    queueAIWarOnPlayer(attackerId, reason);
+    return true;
+  }
+  if (isPlayerAlly(defenderId)) {
+    queueAllyAttacked(attackerId, defenderId);
+    return true;
+  }
+  return false;
+}

--- a/style.css
+++ b/style.css
@@ -702,6 +702,7 @@ a:hover { text-decoration: underline; }
 .relation-friendly { background: rgba(106,171,92,0.2); color: #6aab5c; }
 .relation-neutral { background: rgba(138,133,120,0.2); color: #8a8578; }
 .relation-hostile { background: rgba(196,92,74,0.2); color: #c45c4a; }
+.relation-at-war { background: rgba(217,83,79,0.3); color: #ff6655; font-weight: bold; }
 .relation-allied { background: rgba(91,141,217,0.2); color: #5b8dd9; }
 
 /* ---- Chat Panel ---- */


### PR DESCRIPTION
## Summary

Fixes four in-game issues reported from live play:

**1. AI agrees to multiple things but only one gets actioned**
Backend `/api/chat` parser used `re.search` which extracted only the FIRST `[ACTION: ...]` tag. When the AI agreed to form an alliance AND attack a common enemy, only the alliance action was processed. Parser now extracts all action tags; response returns `actions: [...]` array plus a backward-compat `action` singular that prefers concrete war/commitment actions over soft agreements. System prompt updated to explicitly encourage multi-action emission.

**2. "Hostile" label shown even when actually at war**
New `getWarAwareRelationLabel(factionId, value)` wrapper checks `game.aiWars` and returns "At War" instead of "Hostile" when the player is at war with the faction. Base-game UI (hover tooltips, selection panel, city hover) updated to use it. New `.relation-at-war` CSS class.

**3. AI war declarations on player are silent / no ally-defense choice**
New `src/war-notifications.js` queues blocking alerts:
- AI declares war on player → blocking `alert()` that must be dismissed
- AI declares war on a player ally → `confirm()` dialog: defend the ally (declare war on attacker) OR abandon the alliance
Wired into all base-game AI-initiated war points (pre-emptive border war, `wage_war_on` commitments). Queue drained after AI processing, before player regains control.

**4. Barbarian camp UX**
- Can now attack the camp with a combat unit sat ON the tile (was adjacent-only)
- "Direct Raids Against" list now filtered to factions with cities/units within 10 hexes of the camp (was listing every known AI opponent regardless of distance)
- `destroy_camp` action validates the unit is actually on-tile

## Test plan
- [x] All 304 tests pass (`npm test`)
- [x] Build succeeds (`npm run build`)
- [x] Python syntax check passes on api/index.py and server.py
- [ ] Manual playtest: agree to alliance + joint attack, verify both actioned; AI declares war, verify blocking alert; ally attacked, verify defend/abandon dialog
