### PR TITLE
fix: allow ranged/barrage units to capture cities

### DIFF
--- a/src/combat.js
+++ b/src/combat.js
@@ -494,13 +494,16 @@ function executeExpansionCityAttack(attacker, factionId, cityIdx, tactic) {
   }
 
   if (ec.hp <= 0) {
-    // Ranged units cannot capture — only reduce to 1 HP
+    // Ranged-only-restriction (legacy): when CAPTURE_MELEE_ONLY is true, ranged
+    // units can't take the city — HP caps at 1 and you must finish with melee.
+    // Currently disabled so both melee and ranged units can capture.
     if (CITY_DEFENSE.CAPTURE_MELEE_ONLY && aType.rangedCombat > 0) {
       ec.hp = 1;
       addEvent(ec.name + ' defenses broken! Send in melee to capture.', 'combat');
       showModBanner('\u{2694}', ec.name + ': 1 HP — melee unit needed to capture!', factionName);
     } else {
-      // Capture expansion city
+      // Capture expansion city — teleport attacker into the city (covers the
+      // ranged case where the attacker was several tiles away)
       attacker.col = ec.col;
       attacker.row = ec.row;
       captureExpansionCity(factionId, cityIdx);
@@ -682,13 +685,16 @@ function executeCityAttack(attacker, factionId, tactic) {
 
   // Check if city falls
   if (fc.hp <= 0) {
-    // Ranged units cannot capture — only reduce to 1 HP
+    // Ranged-only-restriction (legacy): when CAPTURE_MELEE_ONLY is true, ranged
+    // units can't take the city — HP caps at 1 and you must finish with melee.
+    // Currently disabled so both melee and ranged units can capture.
     if (CITY_DEFENSE.CAPTURE_MELEE_ONLY && aType.rangedCombat > 0) {
       fc.hp = 1;
       addEvent(fc.name + ' defenses broken! Send in melee to capture.', 'combat');
       showModBanner('\u{2694}', fc.name + ': 1 HP \u2014 melee unit needed to capture!', factionName);
     } else {
-      // City captured! Move attacker onto city if melee
+      // City captured! Teleport attacker into the city (covers the ranged case
+      // where the attacker was several tiles away from the city when it fell).
       attacker.col = fc.col;
       attacker.row = fc.row;
       captureFactionCity(factionId);

--- a/src/constants.js
+++ b/src/constants.js
@@ -23,7 +23,10 @@ export const CITY_DEFENSE = {
   RANGED_STRIKE_STRENGTH: 12,
   HP_HEAL_PER_TURN: 5,
   HP_HEAL_NOT_ATTACKED: 10,
-  CAPTURE_MELEE_ONLY: true,
+  // Any unit — melee or ranged — can capture a city by reducing its HP to 0.
+  // When a ranged unit delivers the killing blow, it is teleported into the
+  // captured city (see captureFactionCity / captureExpansionCity in combat.js).
+  CAPTURE_MELEE_ONLY: false,
 };
 
 export const WALL_HP = {


### PR DESCRIPTION
## Summary
- Flips `CITY_DEFENSE.CAPTURE_MELEE_ONLY` from `true` to `false` in `src/constants.js`
- A ranged unit that drops a city's HP to 0 now captures it (previously capped at 1 HP with a "send in melee to capture" message)
- Applies to both faction capitals (`captureFactionCity`) and AI expansion cities (`captureExpansionCity`)
- The existing capture path already teleports the attacker onto the captured tile, so no additional movement logic needed

## Test plan
- [x] All 304 tests pass (`npm test`)
- [x] Build succeeds (`npm run build`)
- [ ] Manual: attack a city with a ranged unit, verify it captures on HP-to-0
