### PR TITLE
fix: allow mining mineable resources on any terrain

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -459,7 +459,7 @@ export const TILE_IMPROVEMENTS = {
   fishing_boats:{ name: 'Fishing Boats',icon: '🎣', turns: 2, requires: 'sailing',   validOn: ['coast','ocean'], yields: { food: 2, gold: 1 }, requiresResource: ['fish'], desc: '+2 Food, +1 Gold (on Fish)' },
 
   // Production & Mining
-  mine:        { name: 'Mine',         icon: '⛏️', turns: 4, requires: 'mining',      validOn: ['hills'], yields: { prod: 2 }, desc: '+2 Production' },
+  mine:        { name: 'Mine',         icon: '⛏️', turns: 4, requires: 'mining',      validOn: ['hills'], alsoValidOnResource: ['iron','copper','gold_ore','gems','obsidian','jade'], yields: { prod: 2 }, desc: '+2 Production (hills, or on any mineable resource tile)' },
   quarry:      { name: 'Quarry',       icon: '🪨', turns: 4, requires: 'masonry',     validOn: ['hills','plains'], yields: { prod: 1, gold: 1 }, requiresResource: ['stone'], desc: '+1 Prod, +1 Gold (on Stone)' },
   lumber_mill: { name: 'Lumber Mill',  icon: '🪓', turns: 3, requires: 'construction', validFeature: ['woods','rainforest'], yields: { prod: 2 }, desc: '+2 Production (in forest, requires Construction)' },
 

--- a/src/improvements.js
+++ b/src/improvements.js
@@ -27,8 +27,13 @@ export function getAvailableImprovements(col, row) {
     // Check if already built (except roads can coexist)
     if (id !== 'road' && tile.improvement === id) continue;
     if (id === 'road' && tile.road) continue;
-    // Check valid terrain
-    if (imp.validOn && !imp.validOn.includes(tile.base) && !(imp.validOn.includes('hills') && tile.feature === 'hills')) continue;
+    // Check valid terrain — but allow override when the tile has a specific
+    // resource the improvement explicitly supports (e.g. mine on any terrain
+    // when the tile has gold_ore/copper/iron/gems/obsidian/jade).
+    if (imp.validOn && !imp.validOn.includes(tile.base) && !(imp.validOn.includes('hills') && tile.feature === 'hills')) {
+      const resourceOverride = imp.alsoValidOnResource && tile.resource && imp.alsoValidOnResource.includes(tile.resource);
+      if (!resourceOverride) continue;
+    }
     // Check valid feature
     if (imp.validFeature && !imp.validFeature.includes(tile.feature)) continue;
     // Check river requirement

--- a/src/turn.js
+++ b/src/turn.js
@@ -1663,7 +1663,10 @@ function tryAIImprove(worker, priority) {
     if (!imp) continue;
     if (impId !== 'road' && tile.improvement === impId) continue;
     if (impId === 'road' && tile.road) continue;
-    if (imp.validOn && !imp.validOn.includes(tile.base) && !(imp.validOn.includes('hills') && tile.feature === 'hills')) continue;
+    if (imp.validOn && !imp.validOn.includes(tile.base) && !(imp.validOn.includes('hills') && tile.feature === 'hills')) {
+      const resourceOverride = imp.alsoValidOnResource && tile.resource && imp.alsoValidOnResource.includes(tile.resource);
+      if (!resourceOverride) continue;
+    }
     if (imp.validFeature && !imp.validFeature.includes(tile.feature)) continue;
     if (imp.requiresRiver && !tile.hasRiver) continue;
     if (imp.requiresResource && (!tile.resource || !imp.requiresResource.includes(tile.resource))) continue;


### PR DESCRIPTION
## Summary
Gold/copper/gems/iron/obsidian/jade sitting on a plains tile couldn't be mined — only hills allowed the mine improvement, so valuable resources on flat terrain were stuck with road or farm.

- Adds `alsoValidOnResource: ['iron','copper','gold_ore','gems','obsidian','jade']` to the mine improvement
- Updates terrain check in `getAvailableImprovements` (player UI) and `turn.js` (AI worker auto-improve) to bypass `validOn` when the tile has one of those resources
- Mining tech is still required; only the terrain restriction is relaxed on resource tiles

## Test plan
- [x] All 304 tests pass (`npm test`)
- [x] Build succeeds (`npm run build`)
- [ ] Manual: stand a worker on a plains tile with gold_ore, verify Mine shows in the action list
