### PR TITLE
feat: Great General heal & pillage; fix coordinated attack

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -18,7 +18,7 @@ import {
 import { setRenderCallback } from './assets.js';
 import { render, resizeCanvas, centerCameraOnCity, computeVisibility } from './render.js';
 import { initInputHandlers, clampCamera, zoomAtCenter, panCameraTo } from './input.js';
-import { createUnit, selectUnit, deselectUnit, selectNextUnit, autoSelectNext, handleHexClick, applyPromotion, computeMoveRange, computeAttackRange, moveUnitTo, placeFactionCities, attachToArmy, detachFromArmy, coordinatedAttack } from './units.js';
+import { createUnit, selectUnit, deselectUnit, selectNextUnit, autoSelectNext, handleHexClick, applyPromotion, computeMoveRange, computeAttackRange, moveUnitTo, placeFactionCities, attachToArmy, detachFromArmy, coordinatedAttack, generalHeal, generalPillage } from './units.js';
 import { resolveCombat, getUnitAt, getPlayerUnitAt, getEnemyUnitAt, getCityAt, showBattlePanel, attackFactionCity, attackExpansionCity } from './combat.js';
 import { endTurn, showTurnSummary, showGameOver, continueAfterVictory } from './turn.js';
 import { togglePanel, closeAllPanels, renderBuildPanel, startBuild, cancelProduction, startWonderBuild, renderResearchPanel, startResearch, setTechGoal, clearTechGoal, renderUnitsPanel, recruitUnit, renderCivicsPanel, toggleCivicsPanel, renderVictoryPanel, toggleVictoryPanel, checkVictoryConditions, showSelectionPanel, hideSelectionPanel, showCityPanel, showTileInfo, showCombatResult, showDeleteConfirm, ensureVictoryPanel, ensureCivicsPanel, computeCityYields, showGiftUnitPanel, giftUnit, toggleGovernmentPanel, openGovernmentPanel, isGovernmentUnlocked, switchBuildCity } from './ui-panels.js';
@@ -95,6 +95,8 @@ window.switchBuildCity = switchBuildCity;
 window.attachToArmy = function(gid, uid) { if (attachToArmy(gid, uid)) { const g = game.units.find(u => u.id === gid); if (g) showSelectionPanel(g); render(); } };
 window.detachFromArmy = function(gid, idx) { if (detachFromArmy(gid, idx)) { const g = game.units.find(u => u.id === gid); if (g) showSelectionPanel(g); render(); } };
 window.coordinatedAttack = function(gid, col, row) { if (coordinatedAttack(gid, col, row)) { const g = game.units.find(u => u.id === gid); if (g) showSelectionPanel(g); updateUI(); render(); } };
+window.generalHeal = function(gid) { if (generalHeal(gid)) { const g = game.units.find(u => u.id === gid); if (g) showSelectionPanel(g); updateUI(); render(); } };
+window.generalPillage = function(gid) { if (generalPillage(gid)) { const g = game.units.find(u => u.id === gid); if (g) showSelectionPanel(g); updateUI(); render(); } };
 
 // --- Expose testing/debug functions ---
 window.triggerEureka = triggerEureka;

--- a/src/ui-panels.js
+++ b/src/ui-panels.js
@@ -20,7 +20,8 @@ import { isTilePassable, getTileMoveCost } from './map.js';
 import { openChat, establishTradeRoute, cancelTradeRoute, renderDiplomacyPanel } from './diplomacy-api.js';
 import { useGreatPerson } from './buildings.js';
 import { hexToRgba } from './utils.js';
-import { attachToArmy, detachFromArmy, coordinatedAttack, getGeneralCapacity } from './units.js';
+import { attachToArmy, detachFromArmy, coordinatedAttack, getGeneralCapacity, generalHeal, generalPillage } from './units.js';
+import { getTileOwner } from './units.js';
 import { calculateCityHousing, getHousingGrowthModifier } from './housing.js';
 
 function showSelectionPanel(unit) {
@@ -353,6 +354,29 @@ function showGeneralPanel(unit) {
       const et = UNIT_TYPES[enemy.type];
       const fName = FACTIONS[enemy.owner]?.name || enemy.owner;
       html += `<button class="sel-btn" style="border-color:#e03030;color:#ff4444;background:rgba(220,40,40,0.15);font-weight:bold" onclick="window.coordinatedAttack(${unit.id},${enemy.col},${enemy.row})"><span>\u{2694} Coordinated Attack: ${et.name} (${fName})</span></button>`;
+    }
+  }
+
+  // Heal — always available when the general has moves and someone needs healing
+  const generalHp = unit.hp !== undefined ? unit.hp : 100;
+  const anyArmyInjured = army.some(u => (u.hp || 100) < 100);
+  if (unit.moveLeft > 0 && (generalHp < 100 || anyArmyInjured)) {
+    html += `<button class="sel-btn" style="border-color:#6aab5c;color:#8fd87f" onclick="window.generalHeal(${unit.id})"><span>\u2764\uFE0F Rest & Heal (+25 HP, ends turn)</span></button>`;
+  }
+
+  // Pillage — when standing on a tile that isn't player-owned
+  if (unit.moveLeft > 0) {
+    const pillageTile = game.map[unit.row]?.[unit.col];
+    const pillageTileOwner = getTileOwner(unit.col, unit.row);
+    const canPillage = pillageTile && pillageTileOwner !== 'player' &&
+      (pillageTile.improvement || pillageTile.road || pillageTileOwner !== null);
+    if (canPillage) {
+      const label = pillageTile.improvement
+        ? `Pillage ${pillageTile.improvement} (+40 HP, +15g)`
+        : pillageTile.road
+          ? 'Pillage road (+20 HP, +5g)'
+          : 'Scorch earth (+15 HP)';
+      html += `<button class="sel-btn" style="border-color:#c45c4a;color:#ff8866" onclick="window.generalPillage(${unit.id})"><span>\uD83D\uDD25 ${label}</span></button>`;
     }
   }
 

--- a/src/units.js
+++ b/src/units.js
@@ -1086,10 +1086,23 @@ function moveArmyTo(general, col, row, callback) {
  */
 function coordinatedAttack(generalId, targetCol, targetRow) {
   const general = game.units.find(u => u.id === generalId);
-  if (!general || !general.army || general.army.length === 0) return false;
+  if (!general) { addEvent('Coordinated attack failed: general not found.', 'combat'); return false; }
+  if (!general.army || general.army.length === 0) {
+    addEvent('Coordinated attack failed: no units in the army.', 'combat');
+    return false;
+  }
+  if (general.hasAttackedThisTurn) {
+    addEvent('Coordinated attack failed: general has already attacked this turn.', 'combat');
+    return false;
+  }
 
-  const target = game.units.find(u => u.col === targetCol && u.row === targetRow && u.owner !== general.owner);
-  if (!target) return false;
+  // Prefer combat units at the target tile over civilians — if a worker and a
+  // warrior share a tile, attacking should hit the warrior.
+  const targetsHere = game.units.filter(u =>
+    u.col === targetCol && u.row === targetRow && u.owner !== general.owner
+  );
+  const target = targetsHere.find(u => UNIT_TYPES[u.type]?.combat > 0) || targetsHere[0];
+  if (!target) { addEvent('Coordinated attack failed: no enemy on that tile.', 'combat'); return false; }
 
   // Check general is adjacent to target
   const dist = hexDistance(general.col, general.row, targetCol, targetRow);
@@ -1161,6 +1174,88 @@ function coordinatedAttack(generalId, targetCol, targetRow) {
   return true;
 }
 
+/**
+ * Great General: spend the turn to heal the general and all attached army
+ * units. Flat 25 HP heal, consumes all remaining movement.
+ */
+function generalHeal(generalId) {
+  const general = game.units.find(u => u.id === generalId && u.type === 'great_general');
+  if (!general || general.owner !== 'player') return false;
+  if (general.moveLeft <= 0) {
+    addEvent('General cannot heal — no movement points remaining.', 'combat');
+    return false;
+  }
+  const HEAL_AMOUNT = 25;
+  const oldHp = general.hp !== undefined ? general.hp : 100;
+  if (general.hp === undefined) general.hp = 100;
+  general.hp = Math.min(100, general.hp + HEAL_AMOUNT);
+  let armyHealed = 0;
+  if (general.army) {
+    for (const u of general.army) {
+      const before = u.hp || 0;
+      u.hp = Math.min(100, before + HEAL_AMOUNT);
+      if (u.hp > before) armyHealed++;
+    }
+  }
+  general.moveLeft = 0;
+  const delta = general.hp - oldHp;
+  addEvent(`\u2695\uFE0F Great General rests and recovers — general +${delta} HP, ${armyHealed} army unit(s) healed.`, 'combat');
+  return true;
+}
+
+/**
+ * Great General: pillage the tile the general is standing on to heal. The
+ * tile must not be in player territory. Pillaging an improvement yields the
+ * most HP and some gold; pillaging a road yields less; scorching raw land
+ * still restores some HP.
+ */
+function generalPillage(generalId) {
+  const general = game.units.find(u => u.id === generalId && u.type === 'great_general');
+  if (!general || general.owner !== 'player') return false;
+  if (general.moveLeft <= 0) {
+    addEvent('General cannot pillage — no movement points remaining.', 'combat');
+    return false;
+  }
+  const tile = game.map[general.row]?.[general.col];
+  if (!tile) return false;
+  const tileOwner = getTileOwner(general.col, general.row);
+  if (tileOwner === 'player') {
+    addEvent('Cannot pillage your own territory.', 'combat');
+    return false;
+  }
+
+  let healAmount = 0;
+  let goldAmount = 0;
+  let msg = '';
+  if (tile.improvement) {
+    const imp = TILE_IMPROVEMENTS[tile.improvement];
+    msg = `Great General pillaged ${imp?.name || 'improvement'}`;
+    tile.improvement = null;
+    tile.improvementProgress = 0;
+    healAmount = 40; goldAmount = 15;
+  } else if (tile.road) {
+    msg = 'Great General pillaged a road';
+    tile.road = false;
+    healAmount = 20; goldAmount = 5;
+  } else {
+    msg = 'Great General scorched the land';
+    healAmount = 15; goldAmount = 0;
+  }
+
+  if (general.hp === undefined) general.hp = 100;
+  const oldHp = general.hp;
+  general.hp = Math.min(100, general.hp + healAmount);
+  if (general.army) {
+    for (const u of general.army) {
+      u.hp = Math.min(100, (u.hp || 0) + healAmount);
+    }
+  }
+  if (goldAmount > 0) game.gold = (game.gold || 0) + goldAmount;
+  general.moveLeft = 0;
+  addEvent(`\uD83D\uDD25 ${msg} (+${general.hp - oldHp} HP${goldAmount ? `, +${goldAmount} gold` : ''}).`, 'combat');
+  return true;
+}
+
 export {
   createUnit,
   placeFactionCities,
@@ -1186,4 +1281,6 @@ export {
   detachFromArmy,
   releaseGeneralArmy,
   coordinatedAttack,
+  generalHeal,
+  generalPillage,
 };


### PR DESCRIPTION
## Summary
- **Heal** button on Great General: +25 HP for general and all attached army units, ends turn
- **Pillage** button (appears when standing on non-player tile): removes improvement/road and heals; scorched earth path also gives some HP
- **Coordinated Attack fix**: finder now prefers combat units over civilians when multiple units share a target tile (previously a stacked civilian would be picked, making the attack look like it did nothing)
- Added clear failure messages to the event log for every coordinated-attack rejection case

## Test plan
- [x] 304 tests pass
- [x] Build succeeds
- [ ] Manual: Heal/Pillage buttons appear on Great General panel; Coordinated Attack now damages the intended unit
