### PR TITLE
feat: daily player feedback digest email

### DIFF
--- a/.github/workflows/feedback-digest.yml
+++ b/.github/workflows/feedback-digest.yml
@@ -2,25 +2,28 @@ name: Feedback Digest
 
 on:
   schedule:
-    - cron: '0 8 * * *'  # Every day at 8am UTC
+    # Every morning at 8am UTC
+    - cron: '0 8 * * *'
   workflow_dispatch:
     inputs:
       hours:
-        description: 'Hours of feedback to include (default: 24)'
+        description: 'Lookback window in hours (default 24)'
         required: false
         default: '24'
       dry_run:
-        description: 'Preview without sending (true/false)'
+        description: 'Preview digest without sending email (true/false)'
         required: false
         default: 'false'
       digest_email:
-        description: 'Override recipient email address'
+        description: 'Recipient email (defaults to DIGEST_EMAIL secret)'
         required: false
         default: ''
 
 jobs:
   digest:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -30,13 +33,12 @@ jobs:
         with:
           python-version: '3.12'
 
-      - name: Send feedback digest
+      - name: Run feedback digest
         env:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
           RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          DIGEST_EMAIL: ${{ github.event.inputs.digest_email || secrets.DIGEST_EMAIL || 'jamie247@gmail.com' }}
           HOURS: ${{ github.event.inputs.hours || '24' }}
           DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
-          DIGEST_EMAIL: ${{ github.event.inputs.digest_email || 'jamie247@gmail.com' }}
         run: python scripts/feedback-digest.py

--- a/.github/workflows/feedback-digest.yml
+++ b/.github/workflows/feedback-digest.yml
@@ -1,0 +1,36 @@
+name: Feedback Digest
+
+on:
+  schedule:
+    # Every morning at 8am UTC
+    - cron: '0 8 * * *'
+  workflow_dispatch:
+    inputs:
+      lookback_hours:
+        description: 'Hours to look back (default: 24)'
+        required: false
+        default: '24'
+
+jobs:
+  digest:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Run feedback digest
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPO: ${{ github.repository }}
+          LOOKBACK_HOURS: ${{ inputs.lookback_hours || '24' }}
+        run: python scripts/feedback-digest.py

--- a/.github/workflows/feedback-digest.yml
+++ b/.github/workflows/feedback-digest.yml
@@ -2,21 +2,26 @@ name: Feedback Digest
 
 on:
   schedule:
-    # Every morning at 8am UTC
+    # Every day at 8am UTC
     - cron: '0 8 * * *'
   workflow_dispatch:
     inputs:
-      lookback_hours:
-        description: 'Hours to look back (default: 24)'
+      since_hours:
+        description: 'Hours of feedback to include (default: 24)'
         required: false
         default: '24'
+      dry_run:
+        description: 'Dry run (no email sent)'
+        required: false
+        type: boolean
+        default: false
+      digest_email:
+        description: 'Override recipient email'
+        required: false
 
 jobs:
   digest:
     runs-on: ubuntu-latest
-    permissions:
-      issues: write
-      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -26,11 +31,12 @@ jobs:
         with:
           python-version: '3.12'
 
-      - name: Run feedback digest
+      - name: Send feedback digest
         env:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_REPO: ${{ github.repository }}
-          LOOKBACK_HOURS: ${{ inputs.lookback_hours || '24' }}
+          RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
+          SINCE_HOURS: ${{ inputs.since_hours || '24' }}
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
+          DIGEST_EMAIL: ${{ inputs.digest_email || 'jamie247@gmail.com' }}
         run: python scripts/feedback-digest.py

--- a/.github/workflows/feedback-digest.yml
+++ b/.github/workflows/feedback-digest.yml
@@ -2,26 +2,26 @@ name: Feedback Digest
 
 on:
   schedule:
-    # Every day at 8am UTC
+    # Every morning at 8am UTC
     - cron: '0 8 * * *'
   workflow_dispatch:
     inputs:
-      since_hours:
-        description: 'Hours of feedback to include (default: 24)'
+      digest_hours:
+        description: 'Hours to look back (default: 24)'
         required: false
         default: '24'
       dry_run:
-        description: 'Dry run (no email sent)'
+        description: 'Dry run (print digest without creating issue)'
         required: false
+        default: 'false'
         type: boolean
-        default: false
-      digest_email:
-        description: 'Override recipient email'
-        required: false
 
 jobs:
   digest:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -31,12 +31,13 @@ jobs:
         with:
           python-version: '3.12'
 
-      - name: Send feedback digest
+      - name: Run feedback digest
         env:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
-          RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
-          SINCE_HOURS: ${{ inputs.since_hours || '24' }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPO: ${{ github.repository }}
+          DIGEST_HOURS: ${{ inputs.digest_hours || '24' }}
           DRY_RUN: ${{ inputs.dry_run || 'false' }}
-          DIGEST_EMAIL: ${{ inputs.digest_email || 'jamie247@gmail.com' }}
         run: python scripts/feedback-digest.py

--- a/.github/workflows/feedback-digest.yml
+++ b/.github/workflows/feedback-digest.yml
@@ -2,19 +2,21 @@ name: Feedback Digest
 
 on:
   schedule:
-    # Every morning at 8am UTC
-    - cron: '0 8 * * *'
+    - cron: '0 8 * * *'  # Every day at 8am UTC
   workflow_dispatch:
     inputs:
       hours:
-        description: 'Lookback window in hours (default 24)'
+        description: 'Hours of feedback to include (default: 24)'
         required: false
         default: '24'
       dry_run:
-        description: 'Preview without sending email (true/false)'
+        description: 'Preview without sending (true/false)'
         required: false
-        type: boolean
-        default: false
+        default: 'false'
+      digest_email:
+        description: 'Override recipient email address'
+        required: false
+        default: ''
 
 jobs:
   digest:
@@ -33,7 +35,8 @@ jobs:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
           RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
-          DIGEST_EMAIL: ${{ secrets.DIGEST_EMAIL }}
-          DRY_RUN: ${{ inputs.dry_run || 'false' }}
-          HOURS: ${{ inputs.hours || '24' }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          HOURS: ${{ github.event.inputs.hours || '24' }}
+          DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
+          DIGEST_EMAIL: ${{ github.event.inputs.digest_email || 'jamie247@gmail.com' }}
         run: python scripts/feedback-digest.py

--- a/.github/workflows/feedback-digest.yml
+++ b/.github/workflows/feedback-digest.yml
@@ -6,22 +6,19 @@ on:
     - cron: '0 8 * * *'
   workflow_dispatch:
     inputs:
-      digest_hours:
-        description: 'Hours to look back (default: 24)'
+      hours:
+        description: 'Lookback window in hours (default 24)'
         required: false
         default: '24'
       dry_run:
-        description: 'Dry run (print digest without creating issue)'
+        description: 'Preview without sending email (true/false)'
         required: false
-        default: 'false'
         type: boolean
+        default: false
 
 jobs:
   digest:
     runs-on: ubuntu-latest
-    permissions:
-      issues: write
-      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -31,13 +28,12 @@ jobs:
         with:
           python-version: '3.12'
 
-      - name: Run feedback digest
+      - name: Send feedback digest
         env:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_REPO: ${{ github.repository }}
-          DIGEST_HOURS: ${{ inputs.digest_hours || '24' }}
+          RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
+          DIGEST_EMAIL: ${{ secrets.DIGEST_EMAIL }}
           DRY_RUN: ${{ inputs.dry_run || 'false' }}
+          HOURS: ${{ inputs.hours || '24' }}
         run: python scripts/feedback-digest.py

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,12 +139,10 @@ Note: `/api/chat` and `/api/characters` are diplomacy endpoints that still live 
 | `scripts/newsletter.html` | Reusable newsletter HTML template (dynamic placeholders) |
 | `scripts/newsletter-launch.html` | Open-source launch announcement template (baked-in content) |
 | `scripts/release-vote.py` | Manages release vote issues: creates changelog, tallies reactions, creates devel→main PR |
+| `scripts/feedback-digest.py` | Daily feedback digest: queries Supabase, synthesises themes via Claude, creates GitHub issue |
 | `scripts/newsletter.sql` | SQL migration for feedback `thanked_at` and player `email_opt_out` columns |
-| `scripts/feedback-digest.py` | Daily email digest of player feedback, categorised by type and prioritised |
 
 **Newsletter system:** Supports two templates (`TEMPLATE=newsletter` or `TEMPLATE=launch`), test-send to a single address (`TEST_EMAIL=...`), dry-run mode, and per-player HMAC-signed unsubscribe links. Only sends to active players (not waitlisted).
-
-**Feedback digest:** Runs daily at 8am UTC via `feedback-digest.yml`. Queries last 24h of feedback from Supabase, groups by category (bugs, features, gameplay, questions), sorts by priority, and sends an HTML email via Resend. Supports `DRY_RUN`, `SINCE_HOURS`, and `DIGEST_EMAIL` overrides via workflow dispatch.
 
 ## Database (Supabase)
 
@@ -190,7 +188,7 @@ Deployed on Vercel (`uncivilised-game-v2` project). Vercel auto-deploys are disa
 - `.github/workflows/conviction-automerge.yml` — auto-merges conviction PRs (`fix/*` → `devel`) after all CI checks pass and at least one approving review. Triggered by `pull_request_review` and `check_suite` events.
 - `.github/workflows/release-vote.yml` — weekly (Monday 12pm UTC) + manual. Creates a "Release Vote" GitHub issue listing changes on `devel` since `main`. Players vote with reactions (thumbs up/down). At 3 net upvotes, a `devel` → `main` PR is created automatically. Runs `scripts/release-vote.py`.
 - `.github/workflows/newsletter.yml` — manual-only workflow to send emails to active players. Inputs: `template` (newsletter/launch), `message`, `subject`, `dry_run`, `test_email`. Runs `scripts/newsletter.py`.
-- `.github/workflows/feedback-digest.yml` — daily at 8am UTC + manual. Sends categorised/prioritised feedback digest email via Resend. Inputs: `since_hours`, `dry_run`, `digest_email`. Runs `scripts/feedback-digest.py`.
+- `.github/workflows/feedback-digest.yml` — daily (8am UTC) + manual. Creates a GitHub Issue summarising the last 24h of player feedback, categorised and prioritised with Claude-synthesised themes. Inputs: `digest_hours`, `dry_run`. Runs `scripts/feedback-digest.py`.
 
 **Important:** `main` is production. Always work on `devel` or feature branches. If you're about to commit to `main` directly or create a PR targeting `main`, confirm with the user first — they likely want to target `devel` instead.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ esbuild resolves these via the `alias` config in `esbuild.config.mjs`.
 ES modules under `src/`, bundled by esbuild into `game.js` (IIFE format, gitignored). Key modules:
 
 | Module | Purpose |
-|--------|---------||
+|--------|--------|
 | `src/main.js` | Entry point, wires modules, exposes window globals |
 | `src/state.js` | Shared mutable state (game, canvas, camera, drag) |
 | `src/constants.js` | Game data: terrain, units, buildings, techs, factions |
@@ -98,7 +98,7 @@ Two near-identical copies: `server.py` (local dev) and `api/index.py` (Vercel pr
 ### Core Endpoints (both server.py and api/index.py)
 
 | Endpoint | Method | Purpose |
-|----------|--------|---------||
+|----------|--------|--------|
 | `/api/chat` | POST | AI diplomacy (requires diplomacy plugin + ANTHROPIC_API_KEY) |
 | `/api/characters` | GET | List available AI leaders |
 | `/api/save` | POST | Save game state (keyed by visitor_id) |
@@ -118,7 +118,7 @@ Two near-identical copies: `server.py` (local dev) and `api/index.py` (Vercel pr
 ### Production-Only Endpoints (api/index.py)
 
 | Endpoint | Method | Purpose |
-|----------|--------|---------||
+|----------|--------|--------|
 | `/api/signup` | POST | Player registration with email verification |
 | `/api/signin` | POST | Player authentication |
 | `/api/verify-token/:token` | GET | Email/token verification |
@@ -132,7 +132,7 @@ Note: `/api/chat` and `/api/characters` are diplomacy endpoints that still live 
 ## Scripts
 
 | Script | Purpose |
-|--------|---------||
+|--------|--------|
 | `scripts/conviction-triage.py` | Auto-triages new GitHub issues with conviction scoring |
 | `scripts/conviction-close.py` | Nightly auto-close of conviction issues resolved by merged PRs |
 | `scripts/newsletter.py` | Sends newsletter emails to active players via Resend API |
@@ -140,12 +140,9 @@ Note: `/api/chat` and `/api/characters` are diplomacy endpoints that still live 
 | `scripts/newsletter-launch.html` | Open-source launch announcement template (baked-in content) |
 | `scripts/release-vote.py` | Manages release vote issues: creates changelog, tallies reactions, creates devel→main PR |
 | `scripts/newsletter.sql` | SQL migration for feedback `thanked_at` and player `email_opt_out` columns |
-| `scripts/feedback-digest.py` | Daily feedback summary — queries last 24h, groups by category/priority, emails digest |
-| `scripts/feedback-digest.html` | HTML email template for the feedback digest |
+| `scripts/feedback-digest.py` | Daily player feedback digest — queries Supabase, groups by category/priority, AI summary, emails via Resend |
 
 **Newsletter system:** Supports two templates (`TEMPLATE=newsletter` or `TEMPLATE=launch`), test-send to a single address (`TEST_EMAIL=...`), dry-run mode, and per-player HMAC-signed unsubscribe links. Only sends to active players (not waitlisted).
-
-**Feedback digest:** Runs daily at 8am UTC via `.github/workflows/feedback-digest.yml`. Queries Supabase for recent feedback, groups by category (bugs, feature requests, gameplay, questions, other) and sorts by priority (critical → low). Sends a formatted email to `DIGEST_EMAIL`. Supports `DRY_RUN=true` and configurable `HOURS` lookback. Can also be triggered manually via workflow dispatch.
 
 ## Database (Supabase)
 
@@ -191,7 +188,7 @@ Deployed on Vercel (`uncivilised-game-v2` project). Vercel auto-deploys are disa
 - `.github/workflows/conviction-automerge.yml` — auto-merges conviction PRs (`fix/*` → `devel`) after all CI checks pass and at least one approving review. Triggered by `pull_request_review` and `check_suite` events.
 - `.github/workflows/release-vote.yml` — weekly (Monday 12pm UTC) + manual. Creates a "Release Vote" GitHub issue listing changes on `devel` since `main`. Players vote with reactions (thumbs up/down). At 3 net upvotes, a `devel` → `main` PR is created automatically. Runs `scripts/release-vote.py`.
 - `.github/workflows/newsletter.yml` — manual-only workflow to send emails to active players. Inputs: `template` (newsletter/launch), `message`, `subject`, `dry_run`, `test_email`. Runs `scripts/newsletter.py`.
-- `.github/workflows/feedback-digest.yml` — daily at 8am UTC + manual. Queries recent feedback from Supabase, categorizes/prioritizes, and emails a digest to the dev team. Inputs: `hours` (lookback window), `dry_run`. Runs `scripts/feedback-digest.py`.
+- `.github/workflows/feedback-digest.yml` — daily at 8am UTC + manual. Queries the `feedback` table, groups by category/priority, generates an AI executive summary via Claude, and emails the digest via Resend. Inputs: `hours` (lookback window, default 24), `dry_run`, `digest_email`. Runs `scripts/feedback-digest.py`.
 
 **Important:** `main` is production. Always work on `devel` or feature branches. If you're about to commit to `main` directly or create a PR targeting `main`, confirm with the user first — they likely want to target `devel` instead.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ esbuild resolves these via the `alias` config in `esbuild.config.mjs`.
 ES modules under `src/`, bundled by esbuild into `game.js` (IIFE format, gitignored). Key modules:
 
 | Module | Purpose |
-|--------|--------|
+|--------|---------||
 | `src/main.js` | Entry point, wires modules, exposes window globals |
 | `src/state.js` | Shared mutable state (game, canvas, camera, drag) |
 | `src/constants.js` | Game data: terrain, units, buildings, techs, factions |
@@ -98,7 +98,7 @@ Two near-identical copies: `server.py` (local dev) and `api/index.py` (Vercel pr
 ### Core Endpoints (both server.py and api/index.py)
 
 | Endpoint | Method | Purpose |
-|----------|--------|--------|
+|----------|--------|---------||
 | `/api/chat` | POST | AI diplomacy (requires diplomacy plugin + ANTHROPIC_API_KEY) |
 | `/api/characters` | GET | List available AI leaders |
 | `/api/save` | POST | Save game state (keyed by visitor_id) |
@@ -118,7 +118,7 @@ Two near-identical copies: `server.py` (local dev) and `api/index.py` (Vercel pr
 ### Production-Only Endpoints (api/index.py)
 
 | Endpoint | Method | Purpose |
-|----------|--------|--------|
+|----------|--------|---------||
 | `/api/signup` | POST | Player registration with email verification |
 | `/api/signin` | POST | Player authentication |
 | `/api/verify-token/:token` | GET | Email/token verification |
@@ -132,17 +132,20 @@ Note: `/api/chat` and `/api/characters` are diplomacy endpoints that still live 
 ## Scripts
 
 | Script | Purpose |
-|--------|--------|
+|--------|---------||
 | `scripts/conviction-triage.py` | Auto-triages new GitHub issues with conviction scoring |
 | `scripts/conviction-close.py` | Nightly auto-close of conviction issues resolved by merged PRs |
 | `scripts/newsletter.py` | Sends newsletter emails to active players via Resend API |
 | `scripts/newsletter.html` | Reusable newsletter HTML template (dynamic placeholders) |
 | `scripts/newsletter-launch.html` | Open-source launch announcement template (baked-in content) |
 | `scripts/release-vote.py` | Manages release vote issues: creates changelog, tallies reactions, creates devel→main PR |
-| `scripts/feedback-digest.py` | Daily feedback digest: queries Supabase, synthesises themes via Claude, creates GitHub issue |
 | `scripts/newsletter.sql` | SQL migration for feedback `thanked_at` and player `email_opt_out` columns |
+| `scripts/feedback-digest.py` | Daily feedback summary — queries last 24h, groups by category/priority, emails digest |
+| `scripts/feedback-digest.html` | HTML email template for the feedback digest |
 
 **Newsletter system:** Supports two templates (`TEMPLATE=newsletter` or `TEMPLATE=launch`), test-send to a single address (`TEST_EMAIL=...`), dry-run mode, and per-player HMAC-signed unsubscribe links. Only sends to active players (not waitlisted).
+
+**Feedback digest:** Runs daily at 8am UTC via `.github/workflows/feedback-digest.yml`. Queries Supabase for recent feedback, groups by category (bugs, feature requests, gameplay, questions, other) and sorts by priority (critical → low). Sends a formatted email to `DIGEST_EMAIL`. Supports `DRY_RUN=true` and configurable `HOURS` lookback. Can also be triggered manually via workflow dispatch.
 
 ## Database (Supabase)
 
@@ -188,7 +191,7 @@ Deployed on Vercel (`uncivilised-game-v2` project). Vercel auto-deploys are disa
 - `.github/workflows/conviction-automerge.yml` — auto-merges conviction PRs (`fix/*` → `devel`) after all CI checks pass and at least one approving review. Triggered by `pull_request_review` and `check_suite` events.
 - `.github/workflows/release-vote.yml` — weekly (Monday 12pm UTC) + manual. Creates a "Release Vote" GitHub issue listing changes on `devel` since `main`. Players vote with reactions (thumbs up/down). At 3 net upvotes, a `devel` → `main` PR is created automatically. Runs `scripts/release-vote.py`.
 - `.github/workflows/newsletter.yml` — manual-only workflow to send emails to active players. Inputs: `template` (newsletter/launch), `message`, `subject`, `dry_run`, `test_email`. Runs `scripts/newsletter.py`.
-- `.github/workflows/feedback-digest.yml` — daily (8am UTC) + manual. Creates a GitHub Issue summarising the last 24h of player feedback, categorised and prioritised with Claude-synthesised themes. Inputs: `digest_hours`, `dry_run`. Runs `scripts/feedback-digest.py`.
+- `.github/workflows/feedback-digest.yml` — daily at 8am UTC + manual. Queries recent feedback from Supabase, categorizes/prioritizes, and emails a digest to the dev team. Inputs: `hours` (lookback window), `dry_run`. Runs `scripts/feedback-digest.py`.
 
 **Important:** `main` is production. Always work on `devel` or feature branches. If you're about to commit to `main` directly or create a PR targeting `main`, confirm with the user first — they likely want to target `devel` instead.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ esbuild resolves these via the `alias` config in `esbuild.config.mjs`.
 ES modules under `src/`, bundled by esbuild into `game.js` (IIFE format, gitignored). Key modules:
 
 | Module | Purpose |
-|--------|---------|
+|--------|--------|
 | `src/main.js` | Entry point, wires modules, exposes window globals |
 | `src/state.js` | Shared mutable state (game, canvas, camera, drag) |
 | `src/constants.js` | Game data: terrain, units, buildings, techs, factions |
@@ -89,6 +89,7 @@ ES modules under `src/`, bundled by esbuild into `game.js` (IIFE format, gitigno
 - **Always run `npm test` before committing, pushing, or creating a PR.** Tests must pass. If tests fail, fix the issue before proceeding.
 - Tests live in `tests/` with fixtures in `tests/fixtures.js` and browser global stubs in `tests/setup.js`
 - Test naming: use `test()` (not `it()`), add `()` after function names in `describe()`, use dummy faction names (`faction_a`, `faction_b`) not real ones
+- When fixing bugs or changing game logic, add a test that covers the fix when practical. Pure UI changes, render tweaks, and trivial one-liners don't need tests.
 
 ## Backend (Python FastAPI)
 
@@ -97,7 +98,7 @@ Two near-identical copies: `server.py` (local dev) and `api/index.py` (Vercel pr
 ### Core Endpoints (both server.py and api/index.py)
 
 | Endpoint | Method | Purpose |
-|----------|--------|---------|
+|----------|--------|--------|
 | `/api/chat` | POST | AI diplomacy (requires diplomacy plugin + ANTHROPIC_API_KEY) |
 | `/api/characters` | GET | List available AI leaders |
 | `/api/save` | POST | Save game state (keyed by visitor_id) |
@@ -117,7 +118,7 @@ Two near-identical copies: `server.py` (local dev) and `api/index.py` (Vercel pr
 ### Production-Only Endpoints (api/index.py)
 
 | Endpoint | Method | Purpose |
-|----------|--------|---------|
+|----------|--------|--------|
 | `/api/signup` | POST | Player registration with email verification |
 | `/api/signin` | POST | Player authentication |
 | `/api/verify-token/:token` | GET | Email/token verification |
@@ -131,16 +132,19 @@ Note: `/api/chat` and `/api/characters` are diplomacy endpoints that still live 
 ## Scripts
 
 | Script | Purpose |
-|--------|---------|
+|--------|--------|
 | `scripts/conviction-triage.py` | Auto-triages new GitHub issues with conviction scoring |
 | `scripts/conviction-close.py` | Nightly auto-close of conviction issues resolved by merged PRs |
 | `scripts/newsletter.py` | Sends newsletter emails to active players via Resend API |
 | `scripts/newsletter.html` | Reusable newsletter HTML template (dynamic placeholders) |
 | `scripts/newsletter-launch.html` | Open-source launch announcement template (baked-in content) |
+| `scripts/release-vote.py` | Manages release vote issues: creates changelog, tallies reactions, creates devel→main PR |
 | `scripts/newsletter.sql` | SQL migration for feedback `thanked_at` and player `email_opt_out` columns |
-| `scripts/feedback-digest.py` | Daily feedback summary posted as a GitHub issue |
+| `scripts/feedback-digest.py` | Daily email digest of player feedback, categorised by type and prioritised |
 
 **Newsletter system:** Supports two templates (`TEMPLATE=newsletter` or `TEMPLATE=launch`), test-send to a single address (`TEST_EMAIL=...`), dry-run mode, and per-player HMAC-signed unsubscribe links. Only sends to active players (not waitlisted).
+
+**Feedback digest:** Runs daily at 8am UTC via `feedback-digest.yml`. Queries last 24h of feedback from Supabase, groups by category (bugs, features, gameplay, questions), sorts by priority, and sends an HTML email via Resend. Supports `DRY_RUN`, `SINCE_HOURS`, and `DIGEST_EMAIL` overrides via workflow dispatch.
 
 ## Database (Supabase)
 
@@ -179,11 +183,14 @@ Deployed on Vercel (`uncivilised-game-v2` project). Vercel auto-deploys are disa
 - `.github/workflows/conviction-triage.yml` — auto-triages new issues with conviction scoring.
 - `.github/workflows/conviction-implement.yml` — comment `/fix` on a conviction-labeled issue to have Claude Code implement it and open a PR. Restricted to repo owners, members, and collaborators.
 - `.github/workflows/conviction-autofix.yml` — runs twice daily (10am/10pm UTC), automatically implements top critical/high priority conviction issues. Uses `autofix-in-progress` and `autofix-attempted` labels to prevent overlap. Max 2 issues per run.
-- `.github/workflows/conviction-close.yml` — nightly (6am UTC) scan that auto-closes conviction issues resolved by merged PRs. Uses direct PR cross-referencing + Claude semantic matching. Supports `dry_run` input via manual dispatch.
+- `.github/workflows/conviction-close.yml` — runs every 6 hours to auto-close conviction issues resolved by merged PRs. Uses a two-phase approach: first marks issues as `pending-close` with a 24-hour grace period, then closes on the next run if no one objects. Skips issues with active autofix work (`autofix-in-progress` label or open `fix/N` PRs). Uses direct PR cross-referencing + Claude semantic matching (with strict false-positive guards). Supports `dry_run` input via manual dispatch.
 - `.github/workflows/pr-preview.yml` — comment `/deploy` on any PR to get a Vercel preview deployment URL posted back as a comment. Restricted to repo owners, members, and collaborators.
 - `.github/workflows/pr-assist.yml` — comment `@claude <request>` on any PR to have Claude Code make further changes, fix issues, or answer questions. Works on both PR comments and review comments. Restricted to repo owners, members, and collaborators.
+- `.github/workflows/pr-review.yml` — comment `/review` on any PR for Claude Code review. Auto-triggers on conviction PRs (`fix/*` branches targeting `devel`). Submits GitHub APPROVE or REQUEST_CHANGES reviews to gate auto-merge.
+- `.github/workflows/conviction-automerge.yml` — auto-merges conviction PRs (`fix/*` → `devel`) after all CI checks pass and at least one approving review. Triggered by `pull_request_review` and `check_suite` events.
+- `.github/workflows/release-vote.yml` — weekly (Monday 12pm UTC) + manual. Creates a "Release Vote" GitHub issue listing changes on `devel` since `main`. Players vote with reactions (thumbs up/down). At 3 net upvotes, a `devel` → `main` PR is created automatically. Runs `scripts/release-vote.py`.
 - `.github/workflows/newsletter.yml` — manual-only workflow to send emails to active players. Inputs: `template` (newsletter/launch), `message`, `subject`, `dry_run`, `test_email`. Runs `scripts/newsletter.py`.
-- `.github/workflows/feedback-digest.yml` — daily (8am UTC) feedback summary posted as a GitHub issue. Groups by category and priority, shows pending items and reporter stats. Supports manual trigger with configurable lookback window.
+- `.github/workflows/feedback-digest.yml` — daily at 8am UTC + manual. Sends categorised/prioritised feedback digest email via Resend. Inputs: `since_hours`, `dry_run`, `digest_email`. Runs `scripts/feedback-digest.py`.
 
 **Important:** `main` is production. Always work on `devel` or feature branches. If you're about to commit to `main` directly or create a PR targeting `main`, confirm with the user first — they likely want to target `devel` instead.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,6 +138,7 @@ Note: `/api/chat` and `/api/characters` are diplomacy endpoints that still live 
 | `scripts/newsletter.html` | Reusable newsletter HTML template (dynamic placeholders) |
 | `scripts/newsletter-launch.html` | Open-source launch announcement template (baked-in content) |
 | `scripts/newsletter.sql` | SQL migration for feedback `thanked_at` and player `email_opt_out` columns |
+| `scripts/feedback-digest.py` | Daily feedback summary posted as a GitHub issue |
 
 **Newsletter system:** Supports two templates (`TEMPLATE=newsletter` or `TEMPLATE=launch`), test-send to a single address (`TEST_EMAIL=...`), dry-run mode, and per-player HMAC-signed unsubscribe links. Only sends to active players (not waitlisted).
 
@@ -182,6 +183,7 @@ Deployed on Vercel (`uncivilised-game-v2` project). Vercel auto-deploys are disa
 - `.github/workflows/pr-preview.yml` — comment `/deploy` on any PR to get a Vercel preview deployment URL posted back as a comment. Restricted to repo owners, members, and collaborators.
 - `.github/workflows/pr-assist.yml` — comment `@claude <request>` on any PR to have Claude Code make further changes, fix issues, or answer questions. Works on both PR comments and review comments. Restricted to repo owners, members, and collaborators.
 - `.github/workflows/newsletter.yml` — manual-only workflow to send emails to active players. Inputs: `template` (newsletter/launch), `message`, `subject`, `dry_run`, `test_email`. Runs `scripts/newsletter.py`.
+- `.github/workflows/feedback-digest.yml` — daily (8am UTC) feedback summary posted as a GitHub issue. Groups by category and priority, shows pending items and reporter stats. Supports manual trigger with configurable lookback window.
 
 **Important:** `main` is production. Always work on `devel` or feature branches. If you're about to commit to `main` directly or create a PR targeting `main`, confirm with the user first — they likely want to target `devel` instead.
 

--- a/scripts/feedback-digest.html
+++ b/scripts/feedback-digest.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html><html><head><meta charset="utf-8">
+<link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@600;700&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+</head>
+<body style="margin:0;padding:0;background:#0d0f0e;font-family:Inter,-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif">
+<table width="100%" cellpadding="0" cellspacing="0" style="background:#0d0f0e;padding:40px 20px"><tr><td align="center">
+<table width="620" cellpadding="0" cellspacing="0" style="max-width:620px;width:100%">
+
+<!-- HEADER -->
+<tr><td style="padding:0 0 10px">
+  <table width="100%" cellpadding="0" cellspacing="0"><tr>
+    <td style="text-align:left;vertical-align:middle">
+      <svg viewBox="0 0 400 60" width="260" height="39" aria-label="Uncivilised Beta" style="display:block">
+        <defs>
+          <linearGradient id="lg" x1="0" y1="0" x2="1" y2="1">
+            <stop offset="0%" stop-color="#c9a84c"/>
+            <stop offset="100%" stop-color="#8b6914"/>
+          </linearGradient>
+        </defs>
+        <text x="0" y="44" font-family="Cormorant Garamond, Georgia, serif" font-weight="700" font-size="48" fill="url(#lg)">UNCIVILISED</text>
+        <line x1="0" y1="54" x2="360" y2="54" stroke="#c9a84c" stroke-width="0.5" opacity="0.6"/>
+      </svg>
+    </td>
+    <td style="text-align:right;vertical-align:middle">
+      <span style="color:#c9a84c;font-family:'Cormorant Garamond',Georgia,serif;font-size:16px;font-weight:600;opacity:0.7">Feedback Digest</span>
+    </td>
+  </tr></table>
+</td></tr>
+
+<!-- gold line -->
+<tr><td style="padding:0 0 20px"><div style="height:1px;background:linear-gradient(to right,#c9a84c50,transparent)"></div></td></tr>
+
+<!-- DATE -->
+<tr><td style="color:#8a8578;font-size:13px;letter-spacing:1px;text-transform:uppercase;padding:0 0 16px">{{date}}</td></tr>
+
+<!-- SUMMARY -->
+{{summary}}
+
+<!-- CATEGORY SECTIONS -->
+{{sections}}
+
+<!-- FOOTER -->
+<tr><td style="padding:24px 0 0"><div style="height:1px;background:linear-gradient(to right,transparent,#c9a84c15,transparent)"></div></td></tr>
+
+<tr><td style="padding:16px 0 0">
+  <table width="100%" cellpadding="0" cellspacing="0"><tr>
+    <td style="color:#5a5548;font-size:12px;line-height:18px;text-align:left">
+      Uncivilised &mdash; Feedback Digest<br>
+      <a href="https://uncivilized.fun" style="color:#8a8578;text-decoration:none">uncivilized.fun</a>
+    </td>
+    <td width="80" style="text-align:right;white-space:nowrap;vertical-align:middle">
+      <a href="https://discord.gg/m8BzGbwmvM" style="text-decoration:none;margin-right:4px;display:inline-block;width:28px;height:28px;line-height:28px;text-align:center;background:#1a1a1a;border-radius:6px;border:1px solid #2a2a28" title="Discord">
+        <img src="https://cdn.simpleicons.org/discord/5a5548" alt="Discord" width="14" height="14" style="vertical-align:middle;border:0">
+      </a>
+      <a href="https://github.com/uncivilised-game/uncivilised-game-base" style="text-decoration:none;display:inline-block;width:28px;height:28px;line-height:28px;text-align:center;background:#1a1a1a;border-radius:6px;border:1px solid #2a2a28" title="GitHub">
+        <img src="https://cdn.simpleicons.org/github/5a5548" alt="GitHub" width="14" height="14" style="vertical-align:middle;border:0">
+      </a>
+    </td>
+  </tr></table>
+</td></tr>
+
+<tr><td style="color:#3a3830;font-size:11px;line-height:17px;padding:12px 0 0;text-align:center">
+  This is an internal digest sent to the development team.
+</td></tr>
+
+</table></td></tr></table></body></html>

--- a/scripts/feedback-digest.py
+++ b/scripts/feedback-digest.py
@@ -1,47 +1,46 @@
 #!/usr/bin/env python3
 """
-Feedback Digest — daily summary of player feedback, categorised and prioritised.
+Feedback Digest — daily summary of in-game player feedback.
 
-Queries Supabase for feedback from the last 24 hours (or custom window),
-groups by category and priority, uses Claude to synthesise themes,
-and creates a GitHub Issue as the daily digest.
+Queries the last 24 hours of feedback from Supabase, groups by category
+and priority, and sends a formatted digest email via Resend.
 
-Runs on a schedule (GitHub Actions) or manually.
-Requires: SUPABASE_URL, SUPABASE_SERVICE_KEY, ANTHROPIC_API_KEY, GITHUB_TOKEN
-Optional: DIGEST_HOURS=24, DRY_RUN=true
+Requires: SUPABASE_URL, SUPABASE_SERVICE_KEY, RESEND_API_KEY, DIGEST_EMAIL
+Optional: DRY_RUN=true, HOURS=48 (lookback window, default 24)
 """
 
+import json
 import os
 import sys
-import json
 import time
-import urllib.request
 import urllib.error
-from datetime import datetime, timezone, timedelta
-from collections import Counter
+import urllib.request
+from collections import defaultdict
+from datetime import datetime, timedelta, timezone
 
 # ── Config ──────────────────────────────────────────────────────────
 SUPABASE_URL = os.environ["SUPABASE_URL"]
 SUPABASE_KEY = os.environ["SUPABASE_SERVICE_KEY"]
-ANTHROPIC_API_KEY = os.environ["ANTHROPIC_API_KEY"]
-GITHUB_TOKEN = os.environ["GITHUB_TOKEN"]
-GITHUB_REPO = os.environ.get("GITHUB_REPO", "uncivilised-game/uncivilised-game-base")
-
-DIGEST_HOURS = int(os.environ.get("DIGEST_HOURS", "24"))
+RESEND_API_KEY = os.environ["RESEND_API_KEY"]
+DIGEST_EMAIL = os.environ["DIGEST_EMAIL"]
 DRY_RUN = os.environ.get("DRY_RUN", "false").lower() == "true"
+HOURS = int(os.environ.get("HOURS", "24"))
 
-CATEGORY_EMOJI = {
-    "bug_report": "🐛",
-    "feature_request": "✨",
-    "gameplay_feedback": "🎮",
-    "question": "❓",
-    "other": "💬",
-}
+FROM_EMAIL = "Uncivilized <hello@uncivilized.fun>"
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 
 PRIORITY_ORDER = {"critical": 0, "high": 1, "medium": 2, "low": 3}
+CATEGORY_LABELS = {
+    "bug_report": "Bug Reports",
+    "feature_request": "Feature Requests",
+    "gameplay_feedback": "Gameplay Feedback",
+    "question": "Questions",
+    "other": "Other",
+}
+CATEGORY_ORDER = list(CATEGORY_LABELS.keys())
 
 
-# ── HTTP helpers (no deps) ──────────────────────────────────────────
+# ── HTTP helpers ────────────────────────────────────────────────────
 def _req(method, url, data=None, headers=None, retries=2):
     headers = headers or {}
     body = json.dumps(data).encode() if data is not None else None
@@ -50,7 +49,7 @@ def _req(method, url, data=None, headers=None, retries=2):
     for attempt in range(retries + 1):
         try:
             req = urllib.request.Request(url, data=body, headers=headers, method=method)
-            with urllib.request.urlopen(req, timeout=60) as resp:
+            with urllib.request.urlopen(req, timeout=30) as resp:
                 raw = resp.read().decode()
                 return json.loads(raw) if raw else {}
         except urllib.error.HTTPError as e:
@@ -73,182 +72,203 @@ def sb_get(path, params=""):
     })
 
 
-def gh_post(path, data):
-    return _req("POST", f"https://api.github.com{path}", data=data, headers={
-        "Authorization": f"Bearer {GITHUB_TOKEN}",
-        "Accept": "application/vnd.github+json",
-        "X-GitHub-Api-Version": "2022-11-28",
-    })
-
-
-# ── Claude synthesis ────────────────────────────────────────────────
-def synthesise_digest(feedback_items):
-    """Use Claude to synthesise themes and highlights from the day's feedback."""
-    items_text = "\n".join(
-        f"- [{fb.get('category', 'other')}][{fb.get('priority', 'medium')}] "
-        f"{fb.get('player_name', 'anon')}: \"{fb.get('message', '')[:200]}\""
-        for fb in feedback_items
+# ── Fetch feedback ──────────────────────────────────────────────────
+def fetch_recent_feedback(hours):
+    since = (datetime.now(timezone.utc) - timedelta(hours=hours)).isoformat()
+    since_encoded = since.replace("+", "%2B")
+    rows = sb_get(
+        "feedback",
+        f"select=id,visitor_id,player_name,message,category,priority,ai_summary,game_state_snapshot,status,created_at"
+        f"&created_at=gte.{since_encoded}"
+        f"&order=created_at.desc"
     )
+    if isinstance(rows, dict) and "error" in rows:
+        print(f"Supabase error: {rows}", file=sys.stderr)
+        return []
+    return rows or []
 
-    result = _req("POST", "https://api.anthropic.com/v1/messages", data={
-        "model": "claude-sonnet-4-20250514",
-        "max_tokens": 800,
-        "messages": [{
-            "role": "user",
-            "content": f"""You are summarising player feedback for Uncivilised, a browser 4X strategy game.
 
-Below are {len(feedback_items)} feedback items from the last {DIGEST_HOURS} hours.
+# ── Group and sort ──────────────────────────────────────────────────
+def build_digest(rows):
+    by_category = defaultdict(list)
+    for row in rows:
+        cat = row.get("category") or "other"
+        by_category[cat].append(row)
 
-{items_text}
+    for cat in by_category:
+        by_category[cat].sort(
+            key=lambda r: PRIORITY_ORDER.get(r.get("priority", "medium"), 2)
+        )
 
-Write a concise digest with these sections. Use markdown. Be direct and actionable.
+    priority_counts = defaultdict(int)
+    category_counts = defaultdict(int)
+    for row in rows:
+        priority_counts[row.get("priority") or "unknown"] += 1
+        category_counts[row.get("category") or "other"] += 1
 
-1. **Key Themes** — 2-4 bullet points on the most common or important themes
-2. **Action Items** — 1-3 specific things the dev team should look at today, prioritised by urgency
-3. **Notable Quotes** — 1-2 standout player quotes that capture the sentiment well (include player name)
+    return by_category, priority_counts, category_counts
 
-Keep the entire response under 300 words. No preamble."""
-        }],
-    }, headers={
-        "x-api-key": ANTHROPIC_API_KEY,
-        "anthropic-version": "2023-06-01",
+
+# ── HTML rendering ──────────────────────────────────────────────────
+PRIORITY_COLORS = {
+    "critical": "#e74c3c",
+    "high": "#e67e22",
+    "medium": "#f1c40f",
+    "low": "#95a5a6",
+}
+
+CATEGORY_COLORS = {
+    "bug_report": "#d9534f",
+    "feature_request": "#5b8dd9",
+    "gameplay_feedback": "#c9a84c",
+    "question": "#8a8578",
+    "other": "#555555",
+}
+
+
+def render_priority_badge(priority):
+    color = PRIORITY_COLORS.get(priority, "#888")
+    return f'<span style="display:inline-block;background:{color};color:#fff;font-size:11px;font-weight:600;padding:2px 8px;border-radius:3px;text-transform:uppercase;letter-spacing:0.5px">{priority}</span>'
+
+
+def render_category_badge(category):
+    color = CATEGORY_COLORS.get(category, "#888")
+    label = CATEGORY_LABELS.get(category, category)
+    return f'<span style="display:inline-block;background:{color}22;color:{color};font-size:11px;font-weight:600;padding:2px 8px;border-radius:3px;border:1px solid {color}44">{label}</span>'
+
+
+def escape(text):
+    if not text:
+        return ""
+    return text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
+
+def render_item_html(row):
+    summary = escape(row.get("ai_summary") or "")
+    message = escape((row.get("message") or "")[:200])
+    priority = row.get("priority") or "medium"
+    player = escape(row.get("player_name") or "Anonymous")
+    created = row.get("created_at", "")[:16].replace("T", " ")
+
+    display_text = summary or message
+    if not display_text:
+        display_text = "(empty)"
+
+    return f"""<tr><td style="padding:8px 12px;border-bottom:1px solid #222220">
+      <div style="display:flex;align-items:center;gap:8px;margin-bottom:4px">
+        {render_priority_badge(priority)}
+        <span style="color:#8a8578;font-size:12px">{player} &middot; {created} UTC</span>
+      </div>
+      <div style="color:#e8e0d0;font-size:14px;line-height:20px">{display_text}</div>
+    </td></tr>"""
+
+
+def render_email(rows, by_category, priority_counts, category_counts, hours):
+    date_str = datetime.now(timezone.utc).strftime("%B %d, %Y")
+    total = len(rows)
+
+    if total == 0:
+        summary_html = f"""<tr><td style="color:#b8b0a0;font-size:15px;line-height:26px;padding:0 0 24px">
+          No new feedback in the last {hours} hours. All quiet on the frontier.
+        </td></tr>"""
+        sections_html = ""
+    else:
+        stat_pills = []
+        for pri in ["critical", "high", "medium", "low"]:
+            count = priority_counts.get(pri, 0)
+            if count > 0:
+                color = PRIORITY_COLORS[pri]
+                stat_pills.append(
+                    f'<span style="display:inline-block;background:{color}22;color:{color};border:1px solid {color}44;'
+                    f'font-size:13px;font-weight:600;padding:4px 12px;border-radius:4px;margin:0 4px 4px 0">'
+                    f'{count} {pri}</span>'
+                )
+
+        summary_html = f"""<tr><td style="padding:0 0 24px">
+          <div style="color:#e8e0d0;font-size:18px;font-weight:600;margin-bottom:8px">{total} feedback items in the last {hours}h</div>
+          <div>{''.join(stat_pills)}</div>
+        </td></tr>"""
+
+        sections = []
+        for cat in CATEGORY_ORDER:
+            items = by_category.get(cat, [])
+            if not items:
+                continue
+            color = CATEGORY_COLORS.get(cat, "#888")
+            label = CATEGORY_LABELS.get(cat, cat)
+            items_html = "".join(render_item_html(r) for r in items)
+            sections.append(f"""<tr><td style="padding:0 0 20px">
+              <div style="color:{color};font-size:16px;font-weight:600;padding:0 0 8px;border-bottom:2px solid {color}44;margin-bottom:0">
+                {label} ({len(items)})
+              </div>
+              <table width="100%" cellpadding="0" cellspacing="0" style="background:#151715;border:1px solid #222220;border-radius:8px;border-top:none">
+                {items_html}
+              </table>
+            </td></tr>""")
+        sections_html = "".join(sections)
+
+    template_path = os.path.join(SCRIPT_DIR, "feedback-digest.html")
+    with open(template_path, "r") as f:
+        template = f.read()
+
+    return template.replace("{{date}}", date_str) \
+                    .replace("{{summary}}", summary_html) \
+                    .replace("{{sections}}", sections_html)
+
+
+# ── Send email ──────────────────────────────────────────────────────
+def send_email(subject, html_body):
+    payload = {
+        "from": FROM_EMAIL,
+        "to": [DIGEST_EMAIL],
+        "subject": subject,
+        "html": html_body,
+    }
+    return _req("POST", "https://api.resend.com/emails", data=payload, headers={
+        "Authorization": f"Bearer {RESEND_API_KEY}",
         "Content-Type": "application/json",
     })
 
-    return result["content"][0]["text"].strip()
 
+# ── Main ────────────────────────────────────────────────────────────
+def main():
+    print(f"Fetching feedback from last {HOURS} hours...")
+    rows = fetch_recent_feedback(HOURS)
+    print(f"Found {len(rows)} feedback items")
 
-# ── Digest formatting ───────────────────────────────────────────────
-def format_digest_body(feedback_items, synthesis, window_start, window_end):
-    """Format the full GitHub Issue body for the digest."""
-    total = len(feedback_items)
-    by_category = Counter(fb.get("category", "other") for fb in feedback_items)
-    by_priority = Counter(fb.get("priority", "medium") for fb in feedback_items)
-    unique_reporters = set(fb.get("player_name", "anon") for fb in feedback_items if fb.get("player_name"))
+    by_category, priority_counts, category_counts = build_digest(rows)
 
-    # Stats bar
-    cat_parts = []
-    for cat in ["bug_report", "feature_request", "gameplay_feedback", "question", "other"]:
-        count = by_category.get(cat, 0)
-        if count > 0:
-            cat_parts.append(f"{CATEGORY_EMOJI.get(cat, '💬')} {cat.replace('_', ' ').title()}: **{count}**")
+    for cat in CATEGORY_ORDER:
+        items = by_category.get(cat, [])
+        if items:
+            label = CATEGORY_LABELS.get(cat, cat)
+            print(f"\n  {label}: {len(items)}")
+            for r in items:
+                pri = r.get("priority", "?")
+                summary = r.get("ai_summary") or (r.get("message") or "")[:80]
+                print(f"    [{pri}] {summary}")
 
-    pri_parts = []
     for pri in ["critical", "high", "medium", "low"]:
-        count = by_priority.get(pri, 0)
-        if count > 0:
-            pri_parts.append(f"{pri}: {count}")
+        count = priority_counts.get(pri, 0)
+        if count:
+            print(f"  {pri}: {count}")
 
-    # Build category sections
-    category_sections = []
-    for cat in ["bug_report", "feature_request", "gameplay_feedback", "question", "other"]:
-        items = [fb for fb in feedback_items if fb.get("category", "other") == cat]
-        if not items:
-            continue
-        items.sort(key=lambda fb: PRIORITY_ORDER.get(fb.get("priority", "medium"), 2))
-        emoji = CATEGORY_EMOJI.get(cat, "💬")
-        label = cat.replace("_", " ").title()
-        lines = []
-        for fb in items:
-            pri = fb.get("priority", "medium")
-            name = fb.get("player_name", "anon")
-            msg = fb.get("message", "")[:150]
-            summary = fb.get("ai_summary", "")
-            display = summary if summary else msg
-            pri_badge = f" `{pri}`" if pri in ("critical", "high") else ""
-            lines.append(f"- **{name}**{pri_badge}: {display}")
-        category_sections.append(f"### {emoji} {label} ({len(items)})\n\n" + "\n".join(lines))
-
-    # Top reporters
-    reporter_counts = Counter(fb.get("player_name", "anon") for fb in feedback_items if fb.get("player_name"))
-    top_reporters = reporter_counts.most_common(5)
-    top_reporters_text = ", ".join(f"{name} ({count})" for name, count in top_reporters) if top_reporters else "—"
-
-    return f"""**{total} feedback items** from {len(unique_reporters)} unique players
-**Period:** {window_start.strftime('%Y-%m-%d %H:%M')} → {window_end.strftime('%Y-%m-%d %H:%M')} UTC
-
-{' · '.join(cat_parts)}
-**Priority breakdown:** {', '.join(pri_parts)}
-
----
-
-## Synthesis
-
-{synthesis}
-
----
-
-## All Feedback by Category
-
-{chr(10).join(category_sections)}
-
----
-
-### Stats
-- **Unique reporters:** {len(unique_reporters)}
-- **Top reporters:** {top_reporters_text}
-
----
-*Auto-generated by feedback digest pipeline.*"""
-
-
-# ── Main pipeline ──────────────────────────────────────────────────
-def run():
-    now = datetime.now(timezone.utc)
-    window_start = now - timedelta(hours=DIGEST_HOURS)
-    date_label = now.strftime("%Y-%m-%d")
-
-    print(f"=== Feedback Digest — {date_label} ===")
-    print(f"Window: last {DIGEST_HOURS}h ({window_start.isoformat()} → {now.isoformat()})")
-
-    # 1. Fetch feedback from the time window
-    iso_start = window_start.isoformat()
-    feedback = sb_get(
-        "feedback",
-        f"created_at=gte.{iso_start}"
-        f"&select=id,message,category,priority,ai_summary,player_name,game_state_snapshot,created_at,status"
-        f"&order=created_at.desc"
-    )
-    print(f"Found {len(feedback)} feedback items in window")
-
-    if not feedback:
-        print("No feedback to digest. Done.")
-        return
-
-    # 2. Synthesise with Claude
-    print("Synthesising themes with Claude...")
-    synthesis = synthesise_digest(feedback)
-    print("Synthesis complete.")
-
-    # 3. Format the digest
-    body = format_digest_body(feedback, synthesis, window_start, now)
-    title = f"Feedback Digest — {date_label}"
-
-    # Count critical/high for labels
-    priorities = [fb.get("priority", "medium") for fb in feedback]
-    labels = ["feedback-digest"]
-    if "critical" in priorities:
-        labels.append("priority:critical")
-    elif "high" in priorities:
-        labels.append("priority:high")
+    date_str = datetime.now(timezone.utc).strftime("%b %d")
+    subject = f"Feedback Digest — {date_str} — {len(rows)} items"
+    html_body = render_email(rows, by_category, priority_counts, category_counts, HOURS)
 
     if DRY_RUN:
-        print(f"\n[DRY RUN] Would create issue: {title}")
-        print(f"Labels: {labels}")
-        print(f"\n{body}")
-        return
-
-    # 4. Create GitHub Issue
-    print(f"Creating digest issue: {title}")
-    issue = gh_post(f"/repos/{GITHUB_REPO}/issues", {
-        "title": title,
-        "body": body,
-        "labels": labels,
-    })
-    print(f"Created issue #{issue['number']}: {issue['html_url']}")
-
-    print(f"\n=== Done. {len(feedback)} items digested. ===")
+        print(f"\n[DRY RUN] Would send to: {DIGEST_EMAIL}")
+        print(f"[DRY RUN] Subject: {subject}")
+        preview_path = os.path.join(SCRIPT_DIR, "feedback-digest-preview.html")
+        with open(preview_path, "w") as f:
+            f.write(html_body)
+        print(f"[DRY RUN] Preview saved to {preview_path}")
+    else:
+        print(f"\nSending digest to {DIGEST_EMAIL}...")
+        result = send_email(subject, html_body)
+        print(f"Sent: {result}")
 
 
 if __name__ == "__main__":
-    run()
+    main()

--- a/scripts/feedback-digest.py
+++ b/scripts/feedback-digest.py
@@ -1,51 +1,63 @@
 #!/usr/bin/env python3
 """
-Feedback Digest — daily summary of player feedback, categorised and prioritised.
+Feedback Digest — daily email summarising player feedback.
 
-Posts a GitHub issue each morning with:
-- New feedback from the last 24 hours grouped by category and priority
-- Overall stats (total feedback, open issues, top themes)
+Queries Supabase for feedback received in the last 24 hours (or since
+SINCE_HOURS), groups by category and priority, and sends a digest email
+via Resend.
 
-Requires: SUPABASE_URL, SUPABASE_SERVICE_KEY, GITHUB_TOKEN
+Runs on a daily cron (GitHub Actions) or manually.
+
+Requires: SUPABASE_URL, SUPABASE_SERVICE_KEY, RESEND_API_KEY
+Optional: DIGEST_EMAIL (default: repo owner), SINCE_HOURS (default: 24),
+          DRY_RUN=true
 """
 
 import os
 import sys
 import json
 import time
+import html
 import urllib.request
 import urllib.error
 from datetime import datetime, timezone, timedelta
+from collections import defaultdict
 
 # ── Config ──────────────────────────────────────────────────────────
 SUPABASE_URL = os.environ["SUPABASE_URL"]
 SUPABASE_KEY = os.environ["SUPABASE_SERVICE_KEY"]
-GITHUB_TOKEN = os.environ["GITHUB_TOKEN"]
-GITHUB_REPO = os.environ.get("GITHUB_REPO", "uncivilised-game/uncivilised-game-base")
+RESEND_API_KEY = os.environ["RESEND_API_KEY"]
 
-LOOKBACK_HOURS = int(os.environ.get("LOOKBACK_HOURS", "24"))
+DIGEST_EMAIL = os.environ.get("DIGEST_EMAIL", "jamie247@gmail.com")
+SINCE_HOURS = int(os.environ.get("SINCE_HOURS", "24"))
+DRY_RUN = os.environ.get("DRY_RUN", "false").lower() == "true"
 
-CATEGORY_EMOJI = {
-    "bug_report": "\U0001f41b",
-    "feature_request": "\U0001f4a1",
-    "gameplay_feedback": "\U0001f3ae",
-    "question": "\u2753",
-    "other": "\U0001f4ac",
-}
+FROM_EMAIL = "Uncivilized <hello@uncivilized.fun>"
 
-CATEGORY_LABEL = {
+CATEGORY_LABELS = {
     "bug_report": "Bug Reports",
     "feature_request": "Feature Requests",
     "gameplay_feedback": "Gameplay Feedback",
     "question": "Questions",
     "other": "Other",
 }
-
+CATEGORY_EMOJI = {
+    "bug_report": "&#128027;",
+    "feature_request": "&#128161;",
+    "gameplay_feedback": "&#127918;",
+    "question": "&#10067;",
+    "other": "&#128172;",
+}
 PRIORITY_ORDER = {"critical": 0, "high": 1, "medium": 2, "low": 3}
-PRIORITY_EMOJI = {"critical": "\U0001f534", "high": "\U0001f7e0", "medium": "\U0001f7e1", "low": "\U0001f7e2"}
+PRIORITY_COLORS = {
+    "critical": "#dc2626",
+    "high": "#ea580c",
+    "medium": "#ca8a04",
+    "low": "#6b7280",
+}
 
 
-# ── HTTP helpers ────────────────────────────────────────────────────
+# ── HTTP helpers (same pattern as other scripts) ───────────────────
 def _req(method, url, data=None, headers=None, retries=2):
     headers = headers or {}
     body = json.dumps(data).encode() if data is not None else None
@@ -54,7 +66,7 @@ def _req(method, url, data=None, headers=None, retries=2):
     for attempt in range(retries + 1):
         try:
             req = urllib.request.Request(url, data=body, headers=headers, method=method)
-            with urllib.request.urlopen(req, timeout=60) as resp:
+            with urllib.request.urlopen(req, timeout=30) as resp:
                 raw = resp.read().decode()
                 return json.loads(raw) if raw else {}
         except urllib.error.HTTPError as e:
@@ -77,192 +89,210 @@ def sb_get(path, params=""):
     })
 
 
-def gh_api(method, endpoint, data=None):
-    url = f"https://api.github.com/repos/{GITHUB_REPO}/{endpoint}"
-    return _req(method, url, data=data, headers={
-        "Authorization": f"Bearer {GITHUB_TOKEN}",
-        "Accept": "application/vnd.github+json",
-        "X-GitHub-Api-Version": "2022-11-28",
+def send_email(to, subject, html_body):
+    return _req("POST", "https://api.resend.com/emails", data={
+        "from": FROM_EMAIL,
+        "to": [to],
+        "subject": subject,
+        "html": html_body,
+    }, headers={
+        "Authorization": f"Bearer {RESEND_API_KEY}",
+        "Content-Type": "application/json",
     })
 
 
-# ── Fetch feedback ─────────────────────────────────────────────────
-def fetch_recent_feedback(since):
-    """Fetch all feedback created since the given datetime."""
-    iso = since.strftime("%Y-%m-%dT%H:%M:%S+00:00")
+# ── Fetch recent feedback ─────────────────────────────────────────
+def fetch_feedback(since_iso):
     params = (
-        f"select=id,player_name,message,category,priority,ai_summary,status,github_issue_number,created_at"
-        f"&created_at=gte.{iso}"
+        f"created_at=gte.{since_iso}"
+        f"&select=id,player_name,visitor_id,message,category,priority,ai_summary,status,github_issue_number,created_at"
         f"&order=created_at.desc"
     )
     return sb_get("feedback", params)
 
 
-def fetch_pending_feedback():
-    """Fetch feedback still in pending status (below conviction threshold)."""
-    params = (
-        f"select=id,player_name,message,category,priority,ai_summary,created_at"
-        f"&status=eq.pending"
-        f"&order=created_at.desc"
-    )
-    return sb_get("feedback", params)
-
-
-def fetch_overall_stats():
-    """Fetch summary counts by category and status."""
-    params = "select=category,status,priority"
-    return sb_get("feedback", params)
-
-
-# ── Build digest ───────────────────────────────────────────────────
-def group_by_category(feedback):
-    """Group feedback items by category, sorted by priority within each group."""
-    groups = {}
-    for item in feedback:
-        cat = item.get("category") or "other"
-        groups.setdefault(cat, []).append(item)
-    # Sort each group by priority
-    for cat in groups:
-        groups[cat].sort(key=lambda x: PRIORITY_ORDER.get(x.get("priority", "medium"), 2))
-    return groups
-
-
-def build_digest(recent, pending, all_feedback):
-    """Build the markdown digest body."""
+# ── Build digest ──────────────────────────────────────────────────
+def build_digest(feedback, since_dt):
     now = datetime.now(timezone.utc)
-    since = now - timedelta(hours=LOOKBACK_HOURS)
+    period = f"{since_dt.strftime('%b %d %H:%M')} – {now.strftime('%b %d %H:%M')} UTC"
 
-    lines = []
+    # Group by category
+    by_category = defaultdict(list)
+    for fb in feedback:
+        by_category[fb.get("category", "other")].append(fb)
 
-    # ── Header stats ───────────────────────────────────────────────
-    total_all_time = len(all_feedback)
-    total_new = len([f for f in all_feedback if f["status"] == "new"])
-    total_pending = len([f for f in all_feedback if f["status"] == "pending"])
-    total_processed = len([f for f in all_feedback if f["status"] == "processed"])
+    # Priority counts
+    priority_counts = defaultdict(int)
+    for fb in feedback:
+        priority_counts[fb.get("priority", "low")] += 1
 
-    lines.append(f"**Period:** last {LOOKBACK_HOURS} hours (since {since.strftime('%Y-%m-%d %H:%M UTC')})")
-    lines.append(f"**New feedback received:** {len(recent)}")
-    lines.append("")
-    lines.append(f"> **All-time totals** — {total_all_time} total | {total_new} new | {total_pending} pending | {total_processed} processed")
-    lines.append("")
-
-    if not recent:
-        lines.append("No new feedback in this period. :tada:")
-        return "\n".join(lines)
-
-    # ── Priority summary ──────────────────────────────────────────
-    priority_counts = {}
-    for item in recent:
-        p = item.get("priority", "medium")
-        priority_counts[p] = priority_counts.get(p, 0) + 1
-
-    priority_parts = []
-    for p in ["critical", "high", "medium", "low"]:
-        if priority_counts.get(p):
-            priority_parts.append(f"{PRIORITY_EMOJI.get(p, '')} {p}: {priority_counts[p]}")
-    if priority_parts:
-        lines.append("### Priority Breakdown")
-        lines.append(" | ".join(priority_parts))
-        lines.append("")
-
-    # ── Feedback by category ──────────────────────────────────────
-    groups = group_by_category(recent)
-
-    # Order categories: bugs first, then features, gameplay, questions, other
-    cat_order = ["bug_report", "feature_request", "gameplay_feedback", "question", "other"]
-    for cat in cat_order:
-        items = groups.get(cat)
-        if not items:
-            continue
-
-        emoji = CATEGORY_EMOJI.get(cat, "")
-        label = CATEGORY_LABEL.get(cat, cat)
-        lines.append(f"### {emoji} {label} ({len(items)})")
-        lines.append("")
-
-        for item in items:
-            priority = item.get("priority", "medium")
-            p_emoji = PRIORITY_EMOJI.get(priority, "")
-            summary = item.get("ai_summary") or item.get("message", "")[:100]
-            player = item.get("player_name") or "anonymous"
-            issue_num = item.get("github_issue_number")
-
-            issue_ref = f" → #{issue_num}" if issue_num else ""
-            lines.append(f"- {p_emoji} **[{priority}]** {summary} — *{player}*{issue_ref}")
-
-        lines.append("")
-
-    # ── Pending feedback (awaiting more signal) ───────────────────
-    if pending:
-        lines.append(f"### \u23f3 Pending Feedback ({len(pending)} items awaiting conviction threshold)")
-        lines.append("")
-        pending_by_cat = group_by_category(pending)
-        for cat in cat_order:
-            items = pending_by_cat.get(cat)
-            if not items:
-                continue
-            label = CATEGORY_LABEL.get(cat, cat)
-            lines.append(f"**{label}:** {len(items)} pending")
-        lines.append("")
-
-    # ── Unique reporters ──────────────────────────────────────────
+    # Unique reporters
     reporters = set()
-    for item in recent:
-        name = item.get("player_name")
-        if name:
-            reporters.add(name)
+    for fb in feedback:
+        name = fb.get("player_name") or fb.get("visitor_id", "anonymous")
+        reporters.add(name)
 
-    if reporters:
-        lines.append(f"### \U0001f465 Unique Reporters ({len(reporters)})")
-        lines.append(", ".join(sorted(reporters)))
-        lines.append("")
+    # Linked to issues
+    linked = sum(1 for fb in feedback if fb.get("github_issue_number"))
 
-    return "\n".join(lines)
+    # ── HTML ──
+    sections = []
+
+    # Summary banner
+    sections.append(f"""
+    <div style="background:#f8fafc;border:1px solid #e2e8f0;border-radius:8px;padding:20px;margin-bottom:24px;">
+        <h2 style="margin:0 0 12px;color:#1e293b;font-size:20px;">Feedback Digest</h2>
+        <p style="margin:0 0 8px;color:#64748b;font-size:14px;">{period}</p>
+        <div style="display:flex;gap:24px;flex-wrap:wrap;">
+            <div><span style="font-size:28px;font-weight:bold;color:#1e293b;">{len(feedback)}</span>
+                <span style="color:#64748b;font-size:13px;"> total</span></div>
+            <div><span style="font-size:28px;font-weight:bold;color:#1e293b;">{len(reporters)}</span>
+                <span style="color:#64748b;font-size:13px;"> reporters</span></div>
+            <div><span style="font-size:28px;font-weight:bold;color:#1e293b;">{linked}</span>
+                <span style="color:#64748b;font-size:13px;"> linked to issues</span></div>
+        </div>
+    </div>
+    """)
+
+    # Priority breakdown
+    if any(priority_counts.values()):
+        pills = []
+        for p in ["critical", "high", "medium", "low"]:
+            count = priority_counts.get(p, 0)
+            if count:
+                color = PRIORITY_COLORS[p]
+                pills.append(
+                    f'<span style="display:inline-block;background:{color};color:#fff;'
+                    f'border-radius:12px;padding:2px 10px;font-size:12px;margin-right:6px;">'
+                    f'{p}: {count}</span>'
+                )
+        sections.append(f"""
+        <div style="margin-bottom:20px;">
+            <strong style="color:#475569;font-size:13px;">By priority:</strong>
+            <div style="margin-top:6px;">{"".join(pills)}</div>
+        </div>
+        """)
+
+    # Category sections (ordered by count)
+    ordered_cats = sorted(by_category.keys(), key=lambda c: len(by_category[c]), reverse=True)
+
+    for cat in ordered_cats:
+        items = by_category[cat]
+        label = CATEGORY_LABELS.get(cat, cat)
+        emoji = CATEGORY_EMOJI.get(cat, "")
+        # Sort items by priority
+        items.sort(key=lambda fb: PRIORITY_ORDER.get(fb.get("priority", "low"), 3))
+
+        rows = []
+        for fb in items:
+            pri = fb.get("priority", "low")
+            pri_color = PRIORITY_COLORS.get(pri, "#6b7280")
+            summary = html.escape(fb.get("ai_summary") or fb.get("message", "")[:120])
+            player = html.escape(fb.get("player_name") or "anonymous")
+            created = fb.get("created_at", "")[:16].replace("T", " ")
+            issue_link = ""
+            if fb.get("github_issue_number"):
+                issue_num = fb["github_issue_number"]
+                issue_link = (
+                    f' <a href="https://github.com/uncivilised-game/uncivilised-game-base/issues/{issue_num}"'
+                    f' style="color:#2563eb;text-decoration:none;font-size:12px;">#{issue_num}</a>'
+                )
+            status_badge = ""
+            if fb.get("status") == "processed":
+                status_badge = ' <span style="color:#16a34a;font-size:11px;">&#10003; triaged</span>'
+            elif fb.get("status") == "pending":
+                status_badge = ' <span style="color:#ca8a04;font-size:11px;">pending</span>'
+
+            rows.append(f"""
+            <tr style="border-bottom:1px solid #f1f5f9;">
+                <td style="padding:8px 12px;vertical-align:top;">
+                    <span style="display:inline-block;width:8px;height:8px;border-radius:50%;background:{pri_color};margin-right:6px;vertical-align:middle;"></span>
+                    <span style="font-size:12px;color:{pri_color};">{pri}</span>
+                </td>
+                <td style="padding:8px 12px;vertical-align:top;">
+                    <div style="font-size:14px;color:#1e293b;">{summary}{issue_link}{status_badge}</div>
+                    <div style="font-size:12px;color:#94a3b8;margin-top:2px;">{player} &middot; {created}</div>
+                </td>
+            </tr>
+            """)
+
+        sections.append(f"""
+        <div style="margin-bottom:28px;">
+            <h3 style="margin:0 0 8px;color:#334155;font-size:16px;">{emoji} {label} ({len(items)})</h3>
+            <table style="width:100%;border-collapse:collapse;">
+                {"".join(rows)}
+            </table>
+        </div>
+        """)
+
+    # Wrap in full email
+    body = f"""
+    <!DOCTYPE html>
+    <html>
+    <head><meta charset="utf-8"></head>
+    <body style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;max-width:640px;margin:0 auto;padding:20px;color:#1e293b;">
+        {"".join(sections)}
+        <hr style="border:none;border-top:1px solid #e2e8f0;margin:24px 0;">
+        <p style="font-size:12px;color:#94a3b8;text-align:center;">
+            Uncivilized Feedback Digest &middot; Auto-generated by GitHub Actions
+        </p>
+    </body>
+    </html>
+    """
+    return body
 
 
-# ── Main ───────────────────────────────────────────────────────────
-def main():
+def build_empty_digest(since_dt):
     now = datetime.now(timezone.utc)
-    since = now - timedelta(hours=LOOKBACK_HOURS)
+    period = f"{since_dt.strftime('%b %d %H:%M')} – {now.strftime('%b %d %H:%M')} UTC"
+    return f"""
+    <!DOCTYPE html>
+    <html>
+    <head><meta charset="utf-8"></head>
+    <body style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;max-width:640px;margin:0 auto;padding:20px;color:#1e293b;">
+        <div style="background:#f8fafc;border:1px solid #e2e8f0;border-radius:8px;padding:20px;text-align:center;">
+            <h2 style="margin:0 0 8px;color:#1e293b;">Feedback Digest</h2>
+            <p style="color:#64748b;font-size:14px;">{period}</p>
+            <p style="color:#94a3b8;font-size:16px;margin-top:16px;">No new feedback in this period. &#127881;</p>
+        </div>
+    </body>
+    </html>
+    """
 
-    print(f"Fetching feedback from last {LOOKBACK_HOURS} hours...")
-    recent = fetch_recent_feedback(since)
-    print(f"  → {len(recent)} new items")
 
-    pending = fetch_pending_feedback()
-    print(f"  → {len(pending)} pending items")
+# ── Main ──────────────────────────────────────────────────────────
+def main():
+    since_dt = datetime.now(timezone.utc) - timedelta(hours=SINCE_HOURS)
+    since_iso = since_dt.strftime("%Y-%m-%dT%H:%M:%S+00:00")
 
-    all_feedback = fetch_overall_stats()
-    print(f"  → {len(all_feedback)} total items all-time")
+    print(f"Fetching feedback since {since_iso} ...")
+    feedback = fetch_feedback(since_iso)
+    print(f"Found {len(feedback)} feedback items")
 
-    body = build_digest(recent, pending, all_feedback)
+    if feedback:
+        subject = f"Feedback Digest: {len(feedback)} items — {datetime.now(timezone.utc).strftime('%b %d')}"
+        body = build_digest(feedback, since_dt)
+    else:
+        subject = f"Feedback Digest: All quiet — {datetime.now(timezone.utc).strftime('%b %d')}"
+        body = build_empty_digest(since_dt)
 
-    date_str = now.strftime("%Y-%m-%d")
-    title = f"Feedback Digest — {date_str}"
+    if DRY_RUN:
+        print(f"\n[DRY RUN] Would send to: {DIGEST_EMAIL}")
+        print(f"Subject: {subject}")
+        print(f"Items: {len(feedback)}")
+        if feedback:
+            by_cat = defaultdict(int)
+            by_pri = defaultdict(int)
+            for fb in feedback:
+                by_cat[fb.get("category", "other")] += 1
+                by_pri[fb.get("priority", "low")] += 1
+            print(f"Categories: {dict(by_cat)}")
+            print(f"Priorities: {dict(by_pri)}")
+        return
 
-    # Check if a digest for today already exists
-    existing = gh_api("GET", f"issues?labels=feedback-digest&state=open&per_page=5")
-    for issue in existing:
-        if date_str in issue.get("title", ""):
-            print(f"Digest for {date_str} already exists (#{issue['number']}), updating...")
-            gh_api("PATCH", f"issues/{issue['number']}", {"body": body})
-            print(f"Updated: {issue['html_url']}")
-            return
-
-    # Create new issue
-    issue = gh_api("POST", "issues", {
-        "title": title,
-        "body": body,
-        "labels": ["feedback-digest"],
-    })
-    print(f"Created: {issue.get('html_url', issue)}")
-
-    # Close yesterday's digest
-    yesterday = (now - timedelta(days=1)).strftime("%Y-%m-%d")
-    for issue in existing:
-        if yesterday in issue.get("title", ""):
-            gh_api("PATCH", f"issues/{issue['number']}", {"state": "closed"})
-            print(f"Closed yesterday's digest #{issue['number']}")
+    print(f"Sending digest to {DIGEST_EMAIL} ...")
+    result = send_email(DIGEST_EMAIL, subject, body)
+    print(f"Sent: {result.get('id', 'ok')}")
 
 
 if __name__ == "__main__":

--- a/scripts/feedback-digest.py
+++ b/scripts/feedback-digest.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+"""
+Feedback Digest — daily summary of player feedback, categorised and prioritised.
+
+Posts a GitHub issue each morning with:
+- New feedback from the last 24 hours grouped by category and priority
+- Overall stats (total feedback, open issues, top themes)
+
+Requires: SUPABASE_URL, SUPABASE_SERVICE_KEY, GITHUB_TOKEN
+"""
+
+import os
+import sys
+import json
+import time
+import urllib.request
+import urllib.error
+from datetime import datetime, timezone, timedelta
+
+# ── Config ──────────────────────────────────────────────────────────
+SUPABASE_URL = os.environ["SUPABASE_URL"]
+SUPABASE_KEY = os.environ["SUPABASE_SERVICE_KEY"]
+GITHUB_TOKEN = os.environ["GITHUB_TOKEN"]
+GITHUB_REPO = os.environ.get("GITHUB_REPO", "uncivilised-game/uncivilised-game-base")
+
+LOOKBACK_HOURS = int(os.environ.get("LOOKBACK_HOURS", "24"))
+
+CATEGORY_EMOJI = {
+    "bug_report": "\U0001f41b",
+    "feature_request": "\U0001f4a1",
+    "gameplay_feedback": "\U0001f3ae",
+    "question": "\u2753",
+    "other": "\U0001f4ac",
+}
+
+CATEGORY_LABEL = {
+    "bug_report": "Bug Reports",
+    "feature_request": "Feature Requests",
+    "gameplay_feedback": "Gameplay Feedback",
+    "question": "Questions",
+    "other": "Other",
+}
+
+PRIORITY_ORDER = {"critical": 0, "high": 1, "medium": 2, "low": 3}
+PRIORITY_EMOJI = {"critical": "\U0001f534", "high": "\U0001f7e0", "medium": "\U0001f7e1", "low": "\U0001f7e2"}
+
+
+# ── HTTP helpers ────────────────────────────────────────────────────
+def _req(method, url, data=None, headers=None, retries=2):
+    headers = headers or {}
+    body = json.dumps(data).encode() if data is not None else None
+    if body and "Content-Type" not in headers:
+        headers["Content-Type"] = "application/json"
+    for attempt in range(retries + 1):
+        try:
+            req = urllib.request.Request(url, data=body, headers=headers, method=method)
+            with urllib.request.urlopen(req, timeout=60) as resp:
+                raw = resp.read().decode()
+                return json.loads(raw) if raw else {}
+        except urllib.error.HTTPError as e:
+            err_body = e.read().decode() if e.fp else ""
+            if attempt == retries:
+                print(f"HTTP {e.code} {method} {url}: {err_body}", file=sys.stderr)
+                raise
+            time.sleep(2 ** attempt)
+        except Exception:
+            if attempt == retries:
+                raise
+            time.sleep(2 ** attempt)
+
+
+def sb_get(path, params=""):
+    url = f"{SUPABASE_URL}/rest/v1/{path}?{params}" if params else f"{SUPABASE_URL}/rest/v1/{path}"
+    return _req("GET", url, headers={
+        "apikey": SUPABASE_KEY,
+        "Authorization": f"Bearer {SUPABASE_KEY}",
+    })
+
+
+def gh_api(method, endpoint, data=None):
+    url = f"https://api.github.com/repos/{GITHUB_REPO}/{endpoint}"
+    return _req(method, url, data=data, headers={
+        "Authorization": f"Bearer {GITHUB_TOKEN}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    })
+
+
+# ── Fetch feedback ─────────────────────────────────────────────────
+def fetch_recent_feedback(since):
+    """Fetch all feedback created since the given datetime."""
+    iso = since.strftime("%Y-%m-%dT%H:%M:%S+00:00")
+    params = (
+        f"select=id,player_name,message,category,priority,ai_summary,status,github_issue_number,created_at"
+        f"&created_at=gte.{iso}"
+        f"&order=created_at.desc"
+    )
+    return sb_get("feedback", params)
+
+
+def fetch_pending_feedback():
+    """Fetch feedback still in pending status (below conviction threshold)."""
+    params = (
+        f"select=id,player_name,message,category,priority,ai_summary,created_at"
+        f"&status=eq.pending"
+        f"&order=created_at.desc"
+    )
+    return sb_get("feedback", params)
+
+
+def fetch_overall_stats():
+    """Fetch summary counts by category and status."""
+    params = "select=category,status,priority"
+    return sb_get("feedback", params)
+
+
+# ── Build digest ───────────────────────────────────────────────────
+def group_by_category(feedback):
+    """Group feedback items by category, sorted by priority within each group."""
+    groups = {}
+    for item in feedback:
+        cat = item.get("category") or "other"
+        groups.setdefault(cat, []).append(item)
+    # Sort each group by priority
+    for cat in groups:
+        groups[cat].sort(key=lambda x: PRIORITY_ORDER.get(x.get("priority", "medium"), 2))
+    return groups
+
+
+def build_digest(recent, pending, all_feedback):
+    """Build the markdown digest body."""
+    now = datetime.now(timezone.utc)
+    since = now - timedelta(hours=LOOKBACK_HOURS)
+
+    lines = []
+
+    # ── Header stats ───────────────────────────────────────────────
+    total_all_time = len(all_feedback)
+    total_new = len([f for f in all_feedback if f["status"] == "new"])
+    total_pending = len([f for f in all_feedback if f["status"] == "pending"])
+    total_processed = len([f for f in all_feedback if f["status"] == "processed"])
+
+    lines.append(f"**Period:** last {LOOKBACK_HOURS} hours (since {since.strftime('%Y-%m-%d %H:%M UTC')})")
+    lines.append(f"**New feedback received:** {len(recent)}")
+    lines.append("")
+    lines.append(f"> **All-time totals** — {total_all_time} total | {total_new} new | {total_pending} pending | {total_processed} processed")
+    lines.append("")
+
+    if not recent:
+        lines.append("No new feedback in this period. :tada:")
+        return "\n".join(lines)
+
+    # ── Priority summary ──────────────────────────────────────────
+    priority_counts = {}
+    for item in recent:
+        p = item.get("priority", "medium")
+        priority_counts[p] = priority_counts.get(p, 0) + 1
+
+    priority_parts = []
+    for p in ["critical", "high", "medium", "low"]:
+        if priority_counts.get(p):
+            priority_parts.append(f"{PRIORITY_EMOJI.get(p, '')} {p}: {priority_counts[p]}")
+    if priority_parts:
+        lines.append("### Priority Breakdown")
+        lines.append(" | ".join(priority_parts))
+        lines.append("")
+
+    # ── Feedback by category ──────────────────────────────────────
+    groups = group_by_category(recent)
+
+    # Order categories: bugs first, then features, gameplay, questions, other
+    cat_order = ["bug_report", "feature_request", "gameplay_feedback", "question", "other"]
+    for cat in cat_order:
+        items = groups.get(cat)
+        if not items:
+            continue
+
+        emoji = CATEGORY_EMOJI.get(cat, "")
+        label = CATEGORY_LABEL.get(cat, cat)
+        lines.append(f"### {emoji} {label} ({len(items)})")
+        lines.append("")
+
+        for item in items:
+            priority = item.get("priority", "medium")
+            p_emoji = PRIORITY_EMOJI.get(priority, "")
+            summary = item.get("ai_summary") or item.get("message", "")[:100]
+            player = item.get("player_name") or "anonymous"
+            issue_num = item.get("github_issue_number")
+
+            issue_ref = f" → #{issue_num}" if issue_num else ""
+            lines.append(f"- {p_emoji} **[{priority}]** {summary} — *{player}*{issue_ref}")
+
+        lines.append("")
+
+    # ── Pending feedback (awaiting more signal) ───────────────────
+    if pending:
+        lines.append(f"### \u23f3 Pending Feedback ({len(pending)} items awaiting conviction threshold)")
+        lines.append("")
+        pending_by_cat = group_by_category(pending)
+        for cat in cat_order:
+            items = pending_by_cat.get(cat)
+            if not items:
+                continue
+            label = CATEGORY_LABEL.get(cat, cat)
+            lines.append(f"**{label}:** {len(items)} pending")
+        lines.append("")
+
+    # ── Unique reporters ──────────────────────────────────────────
+    reporters = set()
+    for item in recent:
+        name = item.get("player_name")
+        if name:
+            reporters.add(name)
+
+    if reporters:
+        lines.append(f"### \U0001f465 Unique Reporters ({len(reporters)})")
+        lines.append(", ".join(sorted(reporters)))
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+# ── Main ───────────────────────────────────────────────────────────
+def main():
+    now = datetime.now(timezone.utc)
+    since = now - timedelta(hours=LOOKBACK_HOURS)
+
+    print(f"Fetching feedback from last {LOOKBACK_HOURS} hours...")
+    recent = fetch_recent_feedback(since)
+    print(f"  → {len(recent)} new items")
+
+    pending = fetch_pending_feedback()
+    print(f"  → {len(pending)} pending items")
+
+    all_feedback = fetch_overall_stats()
+    print(f"  → {len(all_feedback)} total items all-time")
+
+    body = build_digest(recent, pending, all_feedback)
+
+    date_str = now.strftime("%Y-%m-%d")
+    title = f"Feedback Digest — {date_str}"
+
+    # Check if a digest for today already exists
+    existing = gh_api("GET", f"issues?labels=feedback-digest&state=open&per_page=5")
+    for issue in existing:
+        if date_str in issue.get("title", ""):
+            print(f"Digest for {date_str} already exists (#{issue['number']}), updating...")
+            gh_api("PATCH", f"issues/{issue['number']}", {"body": body})
+            print(f"Updated: {issue['html_url']}")
+            return
+
+    # Create new issue
+    issue = gh_api("POST", "issues", {
+        "title": title,
+        "body": body,
+        "labels": ["feedback-digest"],
+    })
+    print(f"Created: {issue.get('html_url', issue)}")
+
+    # Close yesterday's digest
+    yesterday = (now - timedelta(days=1)).strftime("%Y-%m-%d")
+    for issue in existing:
+        if yesterday in issue.get("title", ""):
+            gh_api("PATCH", f"issues/{issue['number']}", {"state": "closed"})
+            print(f"Closed yesterday's digest #{issue['number']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/feedback-digest.py
+++ b/scripts/feedback-digest.py
@@ -1,63 +1,47 @@
 #!/usr/bin/env python3
 """
-Feedback Digest — daily email summarising player feedback.
+Feedback Digest — daily summary of player feedback, categorised and prioritised.
 
-Queries Supabase for feedback received in the last 24 hours (or since
-SINCE_HOURS), groups by category and priority, and sends a digest email
-via Resend.
+Queries Supabase for feedback from the last 24 hours (or custom window),
+groups by category and priority, uses Claude to synthesise themes,
+and creates a GitHub Issue as the daily digest.
 
-Runs on a daily cron (GitHub Actions) or manually.
-
-Requires: SUPABASE_URL, SUPABASE_SERVICE_KEY, RESEND_API_KEY
-Optional: DIGEST_EMAIL (default: repo owner), SINCE_HOURS (default: 24),
-          DRY_RUN=true
+Runs on a schedule (GitHub Actions) or manually.
+Requires: SUPABASE_URL, SUPABASE_SERVICE_KEY, ANTHROPIC_API_KEY, GITHUB_TOKEN
+Optional: DIGEST_HOURS=24, DRY_RUN=true
 """
 
 import os
 import sys
 import json
 import time
-import html
 import urllib.request
 import urllib.error
 from datetime import datetime, timezone, timedelta
-from collections import defaultdict
+from collections import Counter
 
 # ── Config ──────────────────────────────────────────────────────────
 SUPABASE_URL = os.environ["SUPABASE_URL"]
 SUPABASE_KEY = os.environ["SUPABASE_SERVICE_KEY"]
-RESEND_API_KEY = os.environ["RESEND_API_KEY"]
+ANTHROPIC_API_KEY = os.environ["ANTHROPIC_API_KEY"]
+GITHUB_TOKEN = os.environ["GITHUB_TOKEN"]
+GITHUB_REPO = os.environ.get("GITHUB_REPO", "uncivilised-game/uncivilised-game-base")
 
-DIGEST_EMAIL = os.environ.get("DIGEST_EMAIL", "jamie247@gmail.com")
-SINCE_HOURS = int(os.environ.get("SINCE_HOURS", "24"))
+DIGEST_HOURS = int(os.environ.get("DIGEST_HOURS", "24"))
 DRY_RUN = os.environ.get("DRY_RUN", "false").lower() == "true"
 
-FROM_EMAIL = "Uncivilized <hello@uncivilized.fun>"
-
-CATEGORY_LABELS = {
-    "bug_report": "Bug Reports",
-    "feature_request": "Feature Requests",
-    "gameplay_feedback": "Gameplay Feedback",
-    "question": "Questions",
-    "other": "Other",
-}
 CATEGORY_EMOJI = {
-    "bug_report": "&#128027;",
-    "feature_request": "&#128161;",
-    "gameplay_feedback": "&#127918;",
-    "question": "&#10067;",
-    "other": "&#128172;",
+    "bug_report": "🐛",
+    "feature_request": "✨",
+    "gameplay_feedback": "🎮",
+    "question": "❓",
+    "other": "💬",
 }
+
 PRIORITY_ORDER = {"critical": 0, "high": 1, "medium": 2, "low": 3}
-PRIORITY_COLORS = {
-    "critical": "#dc2626",
-    "high": "#ea580c",
-    "medium": "#ca8a04",
-    "low": "#6b7280",
-}
 
 
-# ── HTTP helpers (same pattern as other scripts) ───────────────────
+# ── HTTP helpers (no deps) ──────────────────────────────────────────
 def _req(method, url, data=None, headers=None, retries=2):
     headers = headers or {}
     body = json.dumps(data).encode() if data is not None else None
@@ -66,7 +50,7 @@ def _req(method, url, data=None, headers=None, retries=2):
     for attempt in range(retries + 1):
         try:
             req = urllib.request.Request(url, data=body, headers=headers, method=method)
-            with urllib.request.urlopen(req, timeout=30) as resp:
+            with urllib.request.urlopen(req, timeout=60) as resp:
                 raw = resp.read().decode()
                 return json.loads(raw) if raw else {}
         except urllib.error.HTTPError as e:
@@ -89,211 +73,182 @@ def sb_get(path, params=""):
     })
 
 
-def send_email(to, subject, html_body):
-    return _req("POST", "https://api.resend.com/emails", data={
-        "from": FROM_EMAIL,
-        "to": [to],
-        "subject": subject,
-        "html": html_body,
-    }, headers={
-        "Authorization": f"Bearer {RESEND_API_KEY}",
-        "Content-Type": "application/json",
+def gh_post(path, data):
+    return _req("POST", f"https://api.github.com{path}", data=data, headers={
+        "Authorization": f"Bearer {GITHUB_TOKEN}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
     })
 
 
-# ── Fetch recent feedback ─────────────────────────────────────────
-def fetch_feedback(since_iso):
-    params = (
-        f"created_at=gte.{since_iso}"
-        f"&select=id,player_name,visitor_id,message,category,priority,ai_summary,status,github_issue_number,created_at"
+# ── Claude synthesis ────────────────────────────────────────────────
+def synthesise_digest(feedback_items):
+    """Use Claude to synthesise themes and highlights from the day's feedback."""
+    items_text = "\n".join(
+        f"- [{fb.get('category', 'other')}][{fb.get('priority', 'medium')}] "
+        f"{fb.get('player_name', 'anon')}: \"{fb.get('message', '')[:200]}\""
+        for fb in feedback_items
+    )
+
+    result = _req("POST", "https://api.anthropic.com/v1/messages", data={
+        "model": "claude-sonnet-4-20250514",
+        "max_tokens": 800,
+        "messages": [{
+            "role": "user",
+            "content": f"""You are summarising player feedback for Uncivilised, a browser 4X strategy game.
+
+Below are {len(feedback_items)} feedback items from the last {DIGEST_HOURS} hours.
+
+{items_text}
+
+Write a concise digest with these sections. Use markdown. Be direct and actionable.
+
+1. **Key Themes** — 2-4 bullet points on the most common or important themes
+2. **Action Items** — 1-3 specific things the dev team should look at today, prioritised by urgency
+3. **Notable Quotes** — 1-2 standout player quotes that capture the sentiment well (include player name)
+
+Keep the entire response under 300 words. No preamble."""
+        }],
+    }, headers={
+        "x-api-key": ANTHROPIC_API_KEY,
+        "anthropic-version": "2023-06-01",
+        "Content-Type": "application/json",
+    })
+
+    return result["content"][0]["text"].strip()
+
+
+# ── Digest formatting ───────────────────────────────────────────────
+def format_digest_body(feedback_items, synthesis, window_start, window_end):
+    """Format the full GitHub Issue body for the digest."""
+    total = len(feedback_items)
+    by_category = Counter(fb.get("category", "other") for fb in feedback_items)
+    by_priority = Counter(fb.get("priority", "medium") for fb in feedback_items)
+    unique_reporters = set(fb.get("player_name", "anon") for fb in feedback_items if fb.get("player_name"))
+
+    # Stats bar
+    cat_parts = []
+    for cat in ["bug_report", "feature_request", "gameplay_feedback", "question", "other"]:
+        count = by_category.get(cat, 0)
+        if count > 0:
+            cat_parts.append(f"{CATEGORY_EMOJI.get(cat, '💬')} {cat.replace('_', ' ').title()}: **{count}**")
+
+    pri_parts = []
+    for pri in ["critical", "high", "medium", "low"]:
+        count = by_priority.get(pri, 0)
+        if count > 0:
+            pri_parts.append(f"{pri}: {count}")
+
+    # Build category sections
+    category_sections = []
+    for cat in ["bug_report", "feature_request", "gameplay_feedback", "question", "other"]:
+        items = [fb for fb in feedback_items if fb.get("category", "other") == cat]
+        if not items:
+            continue
+        items.sort(key=lambda fb: PRIORITY_ORDER.get(fb.get("priority", "medium"), 2))
+        emoji = CATEGORY_EMOJI.get(cat, "💬")
+        label = cat.replace("_", " ").title()
+        lines = []
+        for fb in items:
+            pri = fb.get("priority", "medium")
+            name = fb.get("player_name", "anon")
+            msg = fb.get("message", "")[:150]
+            summary = fb.get("ai_summary", "")
+            display = summary if summary else msg
+            pri_badge = f" `{pri}`" if pri in ("critical", "high") else ""
+            lines.append(f"- **{name}**{pri_badge}: {display}")
+        category_sections.append(f"### {emoji} {label} ({len(items)})\n\n" + "\n".join(lines))
+
+    # Top reporters
+    reporter_counts = Counter(fb.get("player_name", "anon") for fb in feedback_items if fb.get("player_name"))
+    top_reporters = reporter_counts.most_common(5)
+    top_reporters_text = ", ".join(f"{name} ({count})" for name, count in top_reporters) if top_reporters else "—"
+
+    return f"""**{total} feedback items** from {len(unique_reporters)} unique players
+**Period:** {window_start.strftime('%Y-%m-%d %H:%M')} → {window_end.strftime('%Y-%m-%d %H:%M')} UTC
+
+{' · '.join(cat_parts)}
+**Priority breakdown:** {', '.join(pri_parts)}
+
+---
+
+## Synthesis
+
+{synthesis}
+
+---
+
+## All Feedback by Category
+
+{chr(10).join(category_sections)}
+
+---
+
+### Stats
+- **Unique reporters:** {len(unique_reporters)}
+- **Top reporters:** {top_reporters_text}
+
+---
+*Auto-generated by feedback digest pipeline.*"""
+
+
+# ── Main pipeline ──────────────────────────────────────────────────
+def run():
+    now = datetime.now(timezone.utc)
+    window_start = now - timedelta(hours=DIGEST_HOURS)
+    date_label = now.strftime("%Y-%m-%d")
+
+    print(f"=== Feedback Digest — {date_label} ===")
+    print(f"Window: last {DIGEST_HOURS}h ({window_start.isoformat()} → {now.isoformat()})")
+
+    # 1. Fetch feedback from the time window
+    iso_start = window_start.isoformat()
+    feedback = sb_get(
+        "feedback",
+        f"created_at=gte.{iso_start}"
+        f"&select=id,message,category,priority,ai_summary,player_name,game_state_snapshot,created_at,status"
         f"&order=created_at.desc"
     )
-    return sb_get("feedback", params)
+    print(f"Found {len(feedback)} feedback items in window")
 
-
-# ── Build digest ──────────────────────────────────────────────────
-def build_digest(feedback, since_dt):
-    now = datetime.now(timezone.utc)
-    period = f"{since_dt.strftime('%b %d %H:%M')} – {now.strftime('%b %d %H:%M')} UTC"
-
-    # Group by category
-    by_category = defaultdict(list)
-    for fb in feedback:
-        by_category[fb.get("category", "other")].append(fb)
-
-    # Priority counts
-    priority_counts = defaultdict(int)
-    for fb in feedback:
-        priority_counts[fb.get("priority", "low")] += 1
-
-    # Unique reporters
-    reporters = set()
-    for fb in feedback:
-        name = fb.get("player_name") or fb.get("visitor_id", "anonymous")
-        reporters.add(name)
-
-    # Linked to issues
-    linked = sum(1 for fb in feedback if fb.get("github_issue_number"))
-
-    # ── HTML ──
-    sections = []
-
-    # Summary banner
-    sections.append(f"""
-    <div style="background:#f8fafc;border:1px solid #e2e8f0;border-radius:8px;padding:20px;margin-bottom:24px;">
-        <h2 style="margin:0 0 12px;color:#1e293b;font-size:20px;">Feedback Digest</h2>
-        <p style="margin:0 0 8px;color:#64748b;font-size:14px;">{period}</p>
-        <div style="display:flex;gap:24px;flex-wrap:wrap;">
-            <div><span style="font-size:28px;font-weight:bold;color:#1e293b;">{len(feedback)}</span>
-                <span style="color:#64748b;font-size:13px;"> total</span></div>
-            <div><span style="font-size:28px;font-weight:bold;color:#1e293b;">{len(reporters)}</span>
-                <span style="color:#64748b;font-size:13px;"> reporters</span></div>
-            <div><span style="font-size:28px;font-weight:bold;color:#1e293b;">{linked}</span>
-                <span style="color:#64748b;font-size:13px;"> linked to issues</span></div>
-        </div>
-    </div>
-    """)
-
-    # Priority breakdown
-    if any(priority_counts.values()):
-        pills = []
-        for p in ["critical", "high", "medium", "low"]:
-            count = priority_counts.get(p, 0)
-            if count:
-                color = PRIORITY_COLORS[p]
-                pills.append(
-                    f'<span style="display:inline-block;background:{color};color:#fff;'
-                    f'border-radius:12px;padding:2px 10px;font-size:12px;margin-right:6px;">'
-                    f'{p}: {count}</span>'
-                )
-        sections.append(f"""
-        <div style="margin-bottom:20px;">
-            <strong style="color:#475569;font-size:13px;">By priority:</strong>
-            <div style="margin-top:6px;">{"".join(pills)}</div>
-        </div>
-        """)
-
-    # Category sections (ordered by count)
-    ordered_cats = sorted(by_category.keys(), key=lambda c: len(by_category[c]), reverse=True)
-
-    for cat in ordered_cats:
-        items = by_category[cat]
-        label = CATEGORY_LABELS.get(cat, cat)
-        emoji = CATEGORY_EMOJI.get(cat, "")
-        # Sort items by priority
-        items.sort(key=lambda fb: PRIORITY_ORDER.get(fb.get("priority", "low"), 3))
-
-        rows = []
-        for fb in items:
-            pri = fb.get("priority", "low")
-            pri_color = PRIORITY_COLORS.get(pri, "#6b7280")
-            summary = html.escape(fb.get("ai_summary") or fb.get("message", "")[:120])
-            player = html.escape(fb.get("player_name") or "anonymous")
-            created = fb.get("created_at", "")[:16].replace("T", " ")
-            issue_link = ""
-            if fb.get("github_issue_number"):
-                issue_num = fb["github_issue_number"]
-                issue_link = (
-                    f' <a href="https://github.com/uncivilised-game/uncivilised-game-base/issues/{issue_num}"'
-                    f' style="color:#2563eb;text-decoration:none;font-size:12px;">#{issue_num}</a>'
-                )
-            status_badge = ""
-            if fb.get("status") == "processed":
-                status_badge = ' <span style="color:#16a34a;font-size:11px;">&#10003; triaged</span>'
-            elif fb.get("status") == "pending":
-                status_badge = ' <span style="color:#ca8a04;font-size:11px;">pending</span>'
-
-            rows.append(f"""
-            <tr style="border-bottom:1px solid #f1f5f9;">
-                <td style="padding:8px 12px;vertical-align:top;">
-                    <span style="display:inline-block;width:8px;height:8px;border-radius:50%;background:{pri_color};margin-right:6px;vertical-align:middle;"></span>
-                    <span style="font-size:12px;color:{pri_color};">{pri}</span>
-                </td>
-                <td style="padding:8px 12px;vertical-align:top;">
-                    <div style="font-size:14px;color:#1e293b;">{summary}{issue_link}{status_badge}</div>
-                    <div style="font-size:12px;color:#94a3b8;margin-top:2px;">{player} &middot; {created}</div>
-                </td>
-            </tr>
-            """)
-
-        sections.append(f"""
-        <div style="margin-bottom:28px;">
-            <h3 style="margin:0 0 8px;color:#334155;font-size:16px;">{emoji} {label} ({len(items)})</h3>
-            <table style="width:100%;border-collapse:collapse;">
-                {"".join(rows)}
-            </table>
-        </div>
-        """)
-
-    # Wrap in full email
-    body = f"""
-    <!DOCTYPE html>
-    <html>
-    <head><meta charset="utf-8"></head>
-    <body style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;max-width:640px;margin:0 auto;padding:20px;color:#1e293b;">
-        {"".join(sections)}
-        <hr style="border:none;border-top:1px solid #e2e8f0;margin:24px 0;">
-        <p style="font-size:12px;color:#94a3b8;text-align:center;">
-            Uncivilized Feedback Digest &middot; Auto-generated by GitHub Actions
-        </p>
-    </body>
-    </html>
-    """
-    return body
-
-
-def build_empty_digest(since_dt):
-    now = datetime.now(timezone.utc)
-    period = f"{since_dt.strftime('%b %d %H:%M')} – {now.strftime('%b %d %H:%M')} UTC"
-    return f"""
-    <!DOCTYPE html>
-    <html>
-    <head><meta charset="utf-8"></head>
-    <body style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;max-width:640px;margin:0 auto;padding:20px;color:#1e293b;">
-        <div style="background:#f8fafc;border:1px solid #e2e8f0;border-radius:8px;padding:20px;text-align:center;">
-            <h2 style="margin:0 0 8px;color:#1e293b;">Feedback Digest</h2>
-            <p style="color:#64748b;font-size:14px;">{period}</p>
-            <p style="color:#94a3b8;font-size:16px;margin-top:16px;">No new feedback in this period. &#127881;</p>
-        </div>
-    </body>
-    </html>
-    """
-
-
-# ── Main ──────────────────────────────────────────────────────────
-def main():
-    since_dt = datetime.now(timezone.utc) - timedelta(hours=SINCE_HOURS)
-    since_iso = since_dt.strftime("%Y-%m-%dT%H:%M:%S+00:00")
-
-    print(f"Fetching feedback since {since_iso} ...")
-    feedback = fetch_feedback(since_iso)
-    print(f"Found {len(feedback)} feedback items")
-
-    if feedback:
-        subject = f"Feedback Digest: {len(feedback)} items — {datetime.now(timezone.utc).strftime('%b %d')}"
-        body = build_digest(feedback, since_dt)
-    else:
-        subject = f"Feedback Digest: All quiet — {datetime.now(timezone.utc).strftime('%b %d')}"
-        body = build_empty_digest(since_dt)
-
-    if DRY_RUN:
-        print(f"\n[DRY RUN] Would send to: {DIGEST_EMAIL}")
-        print(f"Subject: {subject}")
-        print(f"Items: {len(feedback)}")
-        if feedback:
-            by_cat = defaultdict(int)
-            by_pri = defaultdict(int)
-            for fb in feedback:
-                by_cat[fb.get("category", "other")] += 1
-                by_pri[fb.get("priority", "low")] += 1
-            print(f"Categories: {dict(by_cat)}")
-            print(f"Priorities: {dict(by_pri)}")
+    if not feedback:
+        print("No feedback to digest. Done.")
         return
 
-    print(f"Sending digest to {DIGEST_EMAIL} ...")
-    result = send_email(DIGEST_EMAIL, subject, body)
-    print(f"Sent: {result.get('id', 'ok')}")
+    # 2. Synthesise with Claude
+    print("Synthesising themes with Claude...")
+    synthesis = synthesise_digest(feedback)
+    print("Synthesis complete.")
+
+    # 3. Format the digest
+    body = format_digest_body(feedback, synthesis, window_start, now)
+    title = f"Feedback Digest — {date_label}"
+
+    # Count critical/high for labels
+    priorities = [fb.get("priority", "medium") for fb in feedback]
+    labels = ["feedback-digest"]
+    if "critical" in priorities:
+        labels.append("priority:critical")
+    elif "high" in priorities:
+        labels.append("priority:high")
+
+    if DRY_RUN:
+        print(f"\n[DRY RUN] Would create issue: {title}")
+        print(f"Labels: {labels}")
+        print(f"\n{body}")
+        return
+
+    # 4. Create GitHub Issue
+    print(f"Creating digest issue: {title}")
+    issue = gh_post(f"/repos/{GITHUB_REPO}/issues", {
+        "title": title,
+        "body": body,
+        "labels": labels,
+    })
+    print(f"Created issue #{issue['number']}: {issue['html_url']}")
+
+    print(f"\n=== Done. {len(feedback)} items digested. ===")
 
 
 if __name__ == "__main__":
-    main()
+    run()

--- a/scripts/feedback-digest.py
+++ b/scripts/feedback-digest.py
@@ -1,309 +1,283 @@
 #!/usr/bin/env python3
 """
-Feedback Digest — daily summary of player feedback, emailed every morning.
+Feedback Digest — daily summary of player feedback, categorised and prioritised.
 
-Queries the Supabase `feedback` table for entries since the last digest,
-groups them by category and priority, generates an executive summary via
-Claude, and sends the report via Resend.
+Queries the last 24 hours of in-game feedback from Supabase, groups by category
+and priority, and emails a digest via Resend.
 
-Cron-triggered by .github/workflows/feedback-digest.yml.
-
-Requires: SUPABASE_URL, SUPABASE_SERVICE_KEY, RESEND_API_KEY, ANTHROPIC_API_KEY
-Optional: DIGEST_EMAIL (default: repo owner), HOURS=24, DRY_RUN=true
+Runs on a daily schedule (GitHub Actions) or manually.
+Requires: SUPABASE_URL, SUPABASE_SERVICE_KEY, RESEND_API_KEY
+Optional: DIGEST_EMAIL (recipient, defaults to hello@uncivilized.fun),
+          HOURS (lookback window, default 24), DRY_RUN=true
 """
 
 import os
 import sys
 import json
-import re
+import time
 import urllib.request
 import urllib.error
 from datetime import datetime, timezone, timedelta
-from urllib.parse import quote
 from collections import defaultdict
 
 # ── Config ──────────────────────────────────────────────────────────
 SUPABASE_URL = os.environ["SUPABASE_URL"]
 SUPABASE_KEY = os.environ["SUPABASE_SERVICE_KEY"]
-RESEND_API_KEY = os.environ.get("RESEND_API_KEY", "")
-ANTHROPIC_API_KEY = os.environ.get("ANTHROPIC_API_KEY", "")
-DIGEST_EMAIL = os.environ.get("DIGEST_EMAIL", "jamie247@gmail.com")
+RESEND_API_KEY = os.environ["RESEND_API_KEY"]
+
+DIGEST_EMAIL = os.environ.get("DIGEST_EMAIL", "hello@uncivilized.fun")
 HOURS = int(os.environ.get("HOURS", "24"))
 DRY_RUN = os.environ.get("DRY_RUN", "false").lower() == "true"
 
-SB_REST = f"{SUPABASE_URL}/rest/v1"
-SB_HEADERS = {
-    "apikey": SUPABASE_KEY,
-    "Authorization": f"Bearer {SUPABASE_KEY}",
-    "Content-Type": "application/json",
-}
-
 FROM_EMAIL = "Uncivilized <hello@uncivilized.fun>"
 
-CATEGORY_LABELS = {
+PRIORITY_ORDER = {"critical": 0, "high": 1, "medium": 2, "low": 3, "unknown": 4}
+PRIORITY_EMOJI = {"critical": "🔴", "high": "🟠", "medium": "🟡", "low": "🟢", "unknown": "⚪"}
+CATEGORY_EMOJI = {
+    "bug_report": "🐛",
+    "feature_request": "💡",
+    "gameplay_feedback": "🎮",
+    "question": "❓",
+    "other": "📝",
+}
+CATEGORY_LABEL = {
     "bug_report": "Bug Reports",
     "feature_request": "Feature Requests",
     "gameplay_feedback": "Gameplay Feedback",
     "question": "Questions",
     "other": "Other",
 }
-
-PRIORITY_ORDER = ["critical", "high", "medium", "low"]
-
-CATEGORY_COLORS = {
-    "bug_report": "#d9534f",
-    "feature_request": "#5b8dd9",
-    "gameplay_feedback": "#c9a84c",
-    "question": "#8a8578",
-    "other": "#555555",
-}
-
-PRIORITY_COLORS = {
-    "critical": "#d9534f",
-    "high": "#e67e22",
-    "medium": "#c9a84c",
-    "low": "#8a8578",
-}
+CATEGORY_ORDER = ["bug_report", "feature_request", "gameplay_feedback", "question", "other"]
 
 
-def sb_get(table, select="*", filters="", order=None, limit=None):
-    url = f"{SB_REST}/{table}?select={quote(select)}"
-    if filters:
-        url += f"&{filters.replace('+', '%2B')}"
-    if order:
-        url += f"&order={order}"
-    if limit:
-        url += f"&limit={limit}"
-    req = urllib.request.Request(url, headers=SB_HEADERS)
-    with urllib.request.urlopen(req, timeout=15) as resp:
-        return json.loads(resp.read())
+# ── HTTP helpers (no deps) ──────────────────────────────────────────
+def _req(method, url, data=None, headers=None, retries=2):
+    headers = headers or {}
+    body = json.dumps(data).encode() if data is not None else None
+    if body and "Content-Type" not in headers:
+        headers["Content-Type"] = "application/json"
+    for attempt in range(retries + 1):
+        try:
+            req = urllib.request.Request(url, data=body, headers=headers, method=method)
+            with urllib.request.urlopen(req, timeout=60) as resp:
+                raw = resp.read().decode()
+                return json.loads(raw) if raw else {}
+        except urllib.error.HTTPError as e:
+            err_body = e.read().decode() if e.fp else ""
+            if attempt == retries:
+                print(f"HTTP {e.code} {method} {url}: {err_body}", file=sys.stderr)
+                raise
+            time.sleep(2 ** attempt)
+        except Exception:
+            if attempt == retries:
+                raise
+            time.sleep(2 ** attempt)
 
 
-def generate_summary(items):
-    if not ANTHROPIC_API_KEY or not items:
-        return None
-    feedback_text = "\n".join(
-        f"- [{it['category']}][{it['priority']}] {it.get('ai_summary') or it.get('message', '')[:120]}"
-        for it in items[:50]
+def sb_get(path, params=""):
+    url = f"{SUPABASE_URL}/rest/v1/{path}?{params}" if params else f"{SUPABASE_URL}/rest/v1/{path}"
+    return _req("GET", url, headers={
+        "apikey": SUPABASE_KEY,
+        "Authorization": f"Bearer {SUPABASE_KEY}",
+    })
+
+
+# ── Fetch feedback ──────────────────────────────────────────────────
+def fetch_feedback(hours):
+    since = (datetime.now(timezone.utc) - timedelta(hours=hours)).isoformat()
+    params = (
+        f"select=id,visitor_id,player_name,category,priority,message,ai_summary,status,created_at"
+        f"&created_at=gte.{since}"
+        f"&order=created_at.desc"
     )
-    payload = json.dumps({
-        "model": "claude-sonnet-4-20250514",
-        "max_tokens": 500,
-        "messages": [{
-            "role": "user",
-            "content": f"""You are an analyst for Uncivilized, a 4X strategy game. Below is the last {HOURS}h of player feedback.
-
-Write a brief executive summary (3-5 bullet points) highlighting:
-1. The most urgent issues players are reporting
-2. The most requested features
-3. Overall player sentiment
-4. Any patterns or recurring themes
-
-Be specific — cite actual feedback where relevant. Keep it concise and actionable.
-
-Feedback:
-{feedback_text}"""
-        }]
-    }).encode()
-    req = urllib.request.Request(
-        "https://api.anthropic.com/v1/messages",
-        data=payload,
-        headers={
-            "Content-Type": "application/json",
-            "x-api-key": ANTHROPIC_API_KEY,
-            "anthropic-version": "2023-06-01",
-        },
-    )
-    try:
-        with urllib.request.urlopen(req, timeout=30) as resp:
-            data = json.loads(resp.read())
-            return data["content"][0]["text"]
-    except Exception as e:
-        print(f"[WARN] Claude summary failed: {e}")
-        return None
+    return sb_get("feedback", params)
 
 
-def build_html(items, summary_text):
+# ── Build digest ────────────────────────────────────────────────────
+def build_digest(feedback, hours):
+    if not feedback:
+        return None, None
+
     now = datetime.now(timezone.utc)
-    since = now - timedelta(hours=HOURS)
+    since = now - timedelta(hours=hours)
 
     by_category = defaultdict(list)
     by_priority = defaultdict(int)
-    for it in items:
-        cat = it.get("category") or "other"
-        pri = it.get("priority") or "medium"
-        by_category[cat].append(it)
+    unique_players = set()
+
+    for f in feedback:
+        cat = f.get("category") or "other"
+        pri = f.get("priority") or "unknown"
+        by_category[cat].append(f)
         by_priority[pri] += 1
+        player = f.get("player_name") or f.get("visitor_id") or "anonymous"
+        unique_players.add(player)
 
-    total = len(items)
-    stats_html = f"""
-    <div style="background:#1a1a2e;padding:20px;border-radius:8px;margin-bottom:24px;">
-      <h2 style="color:#c9a84c;margin:0 0 16px 0;font-size:20px;">
-        \U0001f4ca {total} feedback item{"s" if total != 1 else ""} in the last {HOURS}h
-      </h2>
-      <div style="display:flex;gap:16px;flex-wrap:wrap;">
-    """
-    for pri in PRIORITY_ORDER:
-        count = by_priority.get(pri, 0)
-        if count:
-            color = PRIORITY_COLORS[pri]
-            stats_html += f"""
-        <div style="background:{color}22;border:1px solid {color};border-radius:6px;padding:8px 16px;">
-          <span style="color:{color};font-weight:bold;font-size:18px;">{count}</span>
-          <span style="color:#ccc;font-size:13px;margin-left:4px;">{pri}</span>
-        </div>"""
-    stats_html += "</div></div>"
+    for cat in by_category:
+        by_category[cat].sort(key=lambda x: PRIORITY_ORDER.get(x.get("priority", "unknown"), 4))
 
-    summary_html = ""
-    if summary_text:
-        formatted = summary_text.replace("\n", "<br>")
-        summary_html = f"""
-    <div style="background:#1a1a2e;padding:20px;border-radius:8px;margin-bottom:24px;border-left:3px solid #5b8dd9;">
-      <h2 style="color:#5b8dd9;margin:0 0 12px 0;font-size:18px;">AI Summary</h2>
-      <div style="color:#ddd;font-size:14px;line-height:1.6;">{formatted}</div>
-    </div>"""
+    total = len(feedback)
+    date_str = now.strftime("%d %b %Y")
 
-    sections_html = ""
-    for cat_key in ["bug_report", "feature_request", "gameplay_feedback", "question", "other"]:
-        cat_items = by_category.get(cat_key, [])
-        if not cat_items:
+    # ── Plain text version ──
+    text = f"Feedback Digest — {date_str}\n"
+    text += f"{total} items from {len(unique_players)} players (last {hours}h)\n\n"
+
+    for cat in CATEGORY_ORDER:
+        items = by_category.get(cat, [])
+        if not items:
             continue
-        cat_items.sort(key=lambda x: PRIORITY_ORDER.index(x.get("priority", "medium"))
-                       if x.get("priority") in PRIORITY_ORDER else 99)
-        color = CATEGORY_COLORS.get(cat_key, "#555")
-        label = CATEGORY_LABELS.get(cat_key, cat_key)
-        sections_html += f"""
-    <div style="margin-bottom:24px;">
-      <h2 style="color:{color};font-size:18px;margin:0 0 12px 0;padding-bottom:8px;border-bottom:1px solid #333;">
-        {label} ({len(cat_items)})
-      </h2>"""
-        for it in cat_items:
-            pri = it.get("priority", "medium")
-            pri_color = PRIORITY_COLORS.get(pri, "#888")
-            summary = it.get("ai_summary") or (it.get("message") or "")[:120]
-            player = it.get("player_name") or "Anonymous"
-            created = it.get("created_at", "")[:16].replace("T", " ")
-            msg_preview = (it.get("message") or "")[:200]
-            if len(it.get("message") or "") > 200:
-                msg_preview += "…"
-            sections_html += f"""
-      <div style="background:#1a1a2e;padding:12px 16px;border-radius:6px;margin-bottom:8px;border-left:3px solid {pri_color};">
-        <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:4px;">
-          <span style="color:#eee;font-weight:bold;font-size:14px;">{summary}</span>
-          <span style="background:{pri_color}33;color:{pri_color};font-size:11px;padding:2px 8px;border-radius:4px;white-space:nowrap;">{pri}</span>
-        </div>
-        <div style="color:#999;font-size:12px;margin-bottom:4px;">\U0001f464 {player} · {created} UTC</div>
-        <div style="color:#aaa;font-size:13px;font-style:italic;">\"{msg_preview}\"</div>
-      </div>"""
-        sections_html += "</div>"
+        text += f"── {CATEGORY_LABEL.get(cat, cat)} ({len(items)}) ──\n"
+        for f in items:
+            pri = f.get("priority", "unknown")
+            summary = f.get("ai_summary") or (f.get("message") or "")[:120]
+            player = f.get("player_name") or "anon"
+            text += f"  [{pri.upper()}] {summary} — {player}\n"
+        text += "\n"
 
-    return f"""<!DOCTYPE html>
+    # ── HTML version ──
+    html = _build_html(feedback, by_category, by_priority, unique_players, total, hours, date_str)
+
+    subject = f"Feedback Digest: {total} items — {date_str}"
+    return subject, html, text
+
+
+def _build_html(feedback, by_category, by_priority, unique_players, total, hours, date_str):
+    critical = by_priority.get("critical", 0)
+    high = by_priority.get("high", 0)
+
+    # Header bar color based on severity
+    if critical > 0:
+        header_bg = "#d9534f"
+        header_note = f"{critical} critical"
+    elif high > 0:
+        header_bg = "#e8924f"
+        header_note = f"{high} high priority"
+    else:
+        header_bg = "#4a7c59"
+        header_note = "no urgent items"
+
+    html = f"""<!DOCTYPE html>
 <html>
-<head><meta charset="utf-8"></head>
-<body style="background:#0d0d1a;color:#eee;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;padding:24px;margin:0;">
-  <div style="max-width:640px;margin:0 auto;">
-    <div style="text-align:center;margin-bottom:24px;">
-      <h1 style="color:#c9a84c;font-size:24px;margin:0;">⚔️ Uncivilized — Player Feedback Digest</h1>
-      <p style="color:#888;font-size:13px;margin:8px 0 0 0;">
-        {since.strftime('%b %d %H:%M')} – {now.strftime('%b %d %H:%M')} UTC
-      </p>
-    </div>
-    {stats_html}
-    {summary_html}
-    {sections_html}
-    <div style="text-align:center;color:#666;font-size:12px;margin-top:32px;padding-top:16px;border-top:1px solid #333;">
-      Feedback Digest · Uncivilized · <a href="https://uncivilized.fun" style="color:#5b8dd9;">uncivilized.fun</a>
-    </div>
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width"></head>
+<body style="margin:0;padding:0;background:#1a1a1a;font-family:-apple-system,BlinkMacSystemFont,sans-serif;">
+<div style="max-width:640px;margin:0 auto;background:#242424;border-radius:8px;overflow:hidden;margin-top:20px;margin-bottom:20px;">
+
+  <!-- Header -->
+  <div style="background:{header_bg};padding:24px 28px;color:#fff;">
+    <h1 style="margin:0;font-size:22px;font-weight:600;">Feedback Digest</h1>
+    <p style="margin:6px 0 0;font-size:14px;opacity:0.9;">{date_str} &middot; {total} items from {len(unique_players)} players &middot; {header_note}</p>
   </div>
+
+  <!-- Summary bar -->
+  <div style="display:flex;padding:16px 28px;background:#2a2a2a;border-bottom:1px solid #333;gap:20px;flex-wrap:wrap;">
+"""
+
+    for pri in ["critical", "high", "medium", "low"]:
+        count = by_priority.get(pri, 0)
+        if count == 0:
+            continue
+        emoji = PRIORITY_EMOJI.get(pri, "")
+        html += f'    <div style="font-size:13px;color:#ccc;">{emoji} {count} {pri}</div>\n'
+
+    html += "  </div>\n\n"
+
+    # Category sections
+    for cat in CATEGORY_ORDER:
+        items = by_category.get(cat, [])
+        if not items:
+            continue
+
+        emoji = CATEGORY_EMOJI.get(cat, "")
+        label = CATEGORY_LABEL.get(cat, cat)
+
+        html += f"""  <!-- {label} -->
+  <div style="padding:20px 28px;border-bottom:1px solid #333;">
+    <h2 style="margin:0 0 14px;font-size:16px;color:#e0d5c1;font-weight:600;">{emoji} {label} ({len(items)})</h2>
+"""
+
+        for f in items:
+            pri = f.get("priority", "unknown")
+            summary = _esc(f.get("ai_summary") or (f.get("message") or "")[:120])
+            player = _esc(f.get("player_name") or "anonymous")
+            ts = _format_time(f.get("created_at"))
+            pri_color = {"critical": "#d9534f", "high": "#e8924f", "medium": "#c9a84c", "low": "#6b8f71"}.get(pri, "#888")
+
+            html += f"""    <div style="margin-bottom:12px;padding:10px 14px;background:#2d2d2d;border-radius:6px;border-left:3px solid {pri_color};">
+      <div style="font-size:14px;color:#ddd;line-height:1.4;">{summary}</div>
+      <div style="margin-top:6px;font-size:12px;color:#888;">
+        <span style="color:{pri_color};font-weight:600;">{pri.upper()}</span>
+        &middot; {player} &middot; {ts}
+      </div>
+    </div>
+"""
+
+        html += "  </div>\n\n"
+
+    # Footer
+    html += """  <div style="padding:16px 28px;text-align:center;">
+    <p style="margin:0;font-size:12px;color:#666;">Uncivilized — daily feedback digest</p>
+  </div>
+
+</div>
 </body>
 </html>"""
 
+    return html
 
-def send_email(subject, html_body):
-    if not RESEND_API_KEY:
-        print("[ERROR] RESEND_API_KEY not set — cannot send email")
-        sys.exit(1)
-    payload = json.dumps({
+
+def _esc(text):
+    import html as html_mod
+    return html_mod.escape(str(text))
+
+
+def _format_time(iso_str):
+    if not iso_str:
+        return ""
+    try:
+        dt = datetime.fromisoformat(iso_str.replace("Z", "+00:00"))
+        return dt.strftime("%H:%M UTC")
+    except Exception:
+        return ""
+
+
+# ── Send email ──────────────────────────────────────────────────────
+def send_email(to, subject, html_body, text_body):
+    data = {
         "from": FROM_EMAIL,
-        "to": [DIGEST_EMAIL],
+        "to": [to],
         "subject": subject,
         "html": html_body,
-    }).encode()
-    req = urllib.request.Request(
-        "https://api.resend.com/emails",
-        data=payload,
-        headers={
-            "Authorization": f"Bearer {RESEND_API_KEY}",
-            "Content-Type": "application/json",
-        },
-    )
-    with urllib.request.urlopen(req, timeout=15) as resp:
-        result = json.loads(resp.read())
-        print(f"[OK] Email sent: {result.get('id', 'unknown')}")
+        "text": text_body,
+    }
+    return _req("POST", "https://api.resend.com/emails", data=data, headers={
+        "Authorization": f"Bearer {RESEND_API_KEY}",
+        "Content-Type": "application/json",
+    })
 
 
+# ── Main ────────────────────────────────────────────────────────────
 def main():
-    now = datetime.now(timezone.utc)
-    since = now - timedelta(hours=HOURS)
-    since_iso = since.isoformat()
+    print(f"Fetching feedback from last {HOURS} hours...")
+    feedback = fetch_feedback(HOURS)
+    print(f"Found {len(feedback)} feedback items")
 
-    print(f"Fetching feedback since {since_iso} ({HOURS}h window)")
-
-    items = sb_get(
-        "feedback",
-        select="id,visitor_id,player_name,message,category,priority,ai_summary,created_at,status",
-        filters=f"created_at=gte.{since_iso}",
-        order="created_at.desc",
-    )
-
-    print(f"Found {len(items)} feedback items")
-
-    if not items:
-        print("No feedback in this period — skipping digest.")
-        if not DRY_RUN:
-            send_email(
-                f"Uncivilized Feedback Digest — No new feedback",
-                build_html([], None),
-            )
+    if not feedback:
+        print("No feedback in this period. Skipping digest.")
         return
 
-    by_cat = defaultdict(int)
-    by_pri = defaultdict(int)
-    for it in items:
-        by_cat[it.get("category", "other")] += 1
-        by_pri[it.get("priority", "medium")] += 1
+    subject, html_body, text_body = build_digest(feedback, HOURS)
 
-    print(f"Categories: {dict(by_cat)}")
-    print(f"Priorities: {dict(by_pri)}")
-
-    summary = generate_summary(items)
-    if summary:
-        print(f"Generated AI summary ({len(summary)} chars)")
-
-    html = build_html(items, summary)
-
-    critical = by_pri.get("critical", 0)
-    high = by_pri.get("high", 0)
-    subject_parts = [f"Uncivilized Feedback Digest — {len(items)} item{'s' if len(items) != 1 else ''}"]
-    if critical:
-        subject_parts.append(f"\U0001f534 {critical} critical")
-    if high:
-        subject_parts.append(f"\U0001f7e0 {high} high")
-    subject = " · ".join(subject_parts)
+    print(f"\nSubject: {subject}")
+    print(f"\n{text_body}")
 
     if DRY_RUN:
-        print(f"\n[DRY RUN] Would send to: {DIGEST_EMAIL}")
-        print(f"[DRY RUN] Subject: {subject}")
-        print(f"[DRY RUN] HTML length: {len(html)} chars")
-        if summary:
-            print(f"\nAI Summary:\n{summary}")
-        for it in items[:10]:
-            print(f"  [{it.get('priority')}] [{it.get('category')}] {it.get('ai_summary', '')[:80]}")
-        if len(items) > 10:
-            print(f"  ... and {len(items) - 10} more")
-    else:
-        send_email(subject, html)
-        print(f"Digest sent to {DIGEST_EMAIL}")
+        print("\n[DRY RUN] Would send to:", DIGEST_EMAIL)
+        return
+
+    print(f"\nSending digest to {DIGEST_EMAIL}...")
+    result = send_email(DIGEST_EMAIL, subject, html_body, text_body)
+    print(f"Sent: {result.get('id', 'ok')}")
 
 
 if __name__ == "__main__":

--- a/scripts/feedback-digest.py
+++ b/scripts/feedback-digest.py
@@ -1,35 +1,45 @@
 #!/usr/bin/env python3
 """
-Feedback Digest — daily summary of in-game player feedback.
+Feedback Digest — daily summary of player feedback, emailed every morning.
 
-Queries the last 24 hours of feedback from Supabase, groups by category
-and priority, and sends a formatted digest email via Resend.
+Queries the Supabase `feedback` table for entries since the last digest,
+groups them by category and priority, generates an executive summary via
+Claude, and sends the report via Resend.
 
-Requires: SUPABASE_URL, SUPABASE_SERVICE_KEY, RESEND_API_KEY, DIGEST_EMAIL
-Optional: DRY_RUN=true, HOURS=48 (lookback window, default 24)
+Cron-triggered by .github/workflows/feedback-digest.yml.
+
+Requires: SUPABASE_URL, SUPABASE_SERVICE_KEY, RESEND_API_KEY, ANTHROPIC_API_KEY
+Optional: DIGEST_EMAIL (default: repo owner), HOURS=24, DRY_RUN=true
 """
 
-import json
 import os
 import sys
-import time
-import urllib.error
+import json
+import re
 import urllib.request
+import urllib.error
+from datetime import datetime, timezone, timedelta
+from urllib.parse import quote
 from collections import defaultdict
-from datetime import datetime, timedelta, timezone
 
 # ── Config ──────────────────────────────────────────────────────────
 SUPABASE_URL = os.environ["SUPABASE_URL"]
 SUPABASE_KEY = os.environ["SUPABASE_SERVICE_KEY"]
-RESEND_API_KEY = os.environ["RESEND_API_KEY"]
-DIGEST_EMAIL = os.environ["DIGEST_EMAIL"]
-DRY_RUN = os.environ.get("DRY_RUN", "false").lower() == "true"
+RESEND_API_KEY = os.environ.get("RESEND_API_KEY", "")
+ANTHROPIC_API_KEY = os.environ.get("ANTHROPIC_API_KEY", "")
+DIGEST_EMAIL = os.environ.get("DIGEST_EMAIL", "jamie247@gmail.com")
 HOURS = int(os.environ.get("HOURS", "24"))
+DRY_RUN = os.environ.get("DRY_RUN", "false").lower() == "true"
+
+SB_REST = f"{SUPABASE_URL}/rest/v1"
+SB_HEADERS = {
+    "apikey": SUPABASE_KEY,
+    "Authorization": f"Bearer {SUPABASE_KEY}",
+    "Content-Type": "application/json",
+}
 
 FROM_EMAIL = "Uncivilized <hello@uncivilized.fun>"
-SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 
-PRIORITY_ORDER = {"critical": 0, "high": 1, "medium": 2, "low": 3}
 CATEGORY_LABELS = {
     "bug_report": "Bug Reports",
     "feature_request": "Feature Requests",
@@ -37,85 +47,8 @@ CATEGORY_LABELS = {
     "question": "Questions",
     "other": "Other",
 }
-CATEGORY_ORDER = list(CATEGORY_LABELS.keys())
 
-
-# ── HTTP helpers ────────────────────────────────────────────────────
-def _req(method, url, data=None, headers=None, retries=2):
-    headers = headers or {}
-    body = json.dumps(data).encode() if data is not None else None
-    if body and "Content-Type" not in headers:
-        headers["Content-Type"] = "application/json"
-    for attempt in range(retries + 1):
-        try:
-            req = urllib.request.Request(url, data=body, headers=headers, method=method)
-            with urllib.request.urlopen(req, timeout=30) as resp:
-                raw = resp.read().decode()
-                return json.loads(raw) if raw else {}
-        except urllib.error.HTTPError as e:
-            err_body = e.read().decode() if e.fp else ""
-            if attempt == retries:
-                print(f"HTTP {e.code} {method} {url}: {err_body}", file=sys.stderr)
-                raise
-            time.sleep(2 ** attempt)
-        except Exception:
-            if attempt == retries:
-                raise
-            time.sleep(2 ** attempt)
-
-
-def sb_get(path, params=""):
-    url = f"{SUPABASE_URL}/rest/v1/{path}?{params}" if params else f"{SUPABASE_URL}/rest/v1/{path}"
-    return _req("GET", url, headers={
-        "apikey": SUPABASE_KEY,
-        "Authorization": f"Bearer {SUPABASE_KEY}",
-    })
-
-
-# ── Fetch feedback ──────────────────────────────────────────────────
-def fetch_recent_feedback(hours):
-    since = (datetime.now(timezone.utc) - timedelta(hours=hours)).isoformat()
-    since_encoded = since.replace("+", "%2B")
-    rows = sb_get(
-        "feedback",
-        f"select=id,visitor_id,player_name,message,category,priority,ai_summary,game_state_snapshot,status,created_at"
-        f"&created_at=gte.{since_encoded}"
-        f"&order=created_at.desc"
-    )
-    if isinstance(rows, dict) and "error" in rows:
-        print(f"Supabase error: {rows}", file=sys.stderr)
-        return []
-    return rows or []
-
-
-# ── Group and sort ──────────────────────────────────────────────────
-def build_digest(rows):
-    by_category = defaultdict(list)
-    for row in rows:
-        cat = row.get("category") or "other"
-        by_category[cat].append(row)
-
-    for cat in by_category:
-        by_category[cat].sort(
-            key=lambda r: PRIORITY_ORDER.get(r.get("priority", "medium"), 2)
-        )
-
-    priority_counts = defaultdict(int)
-    category_counts = defaultdict(int)
-    for row in rows:
-        priority_counts[row.get("priority") or "unknown"] += 1
-        category_counts[row.get("category") or "other"] += 1
-
-    return by_category, priority_counts, category_counts
-
-
-# ── HTML rendering ──────────────────────────────────────────────────
-PRIORITY_COLORS = {
-    "critical": "#e74c3c",
-    "high": "#e67e22",
-    "medium": "#f1c40f",
-    "low": "#95a5a6",
-}
+PRIORITY_ORDER = ["critical", "high", "medium", "low"]
 
 CATEGORY_COLORS = {
     "bug_report": "#d9534f",
@@ -125,149 +58,252 @@ CATEGORY_COLORS = {
     "other": "#555555",
 }
 
-
-def render_priority_badge(priority):
-    color = PRIORITY_COLORS.get(priority, "#888")
-    return f'<span style="display:inline-block;background:{color};color:#fff;font-size:11px;font-weight:600;padding:2px 8px;border-radius:3px;text-transform:uppercase;letter-spacing:0.5px">{priority}</span>'
-
-
-def render_category_badge(category):
-    color = CATEGORY_COLORS.get(category, "#888")
-    label = CATEGORY_LABELS.get(category, category)
-    return f'<span style="display:inline-block;background:{color}22;color:{color};font-size:11px;font-weight:600;padding:2px 8px;border-radius:3px;border:1px solid {color}44">{label}</span>'
+PRIORITY_COLORS = {
+    "critical": "#d9534f",
+    "high": "#e67e22",
+    "medium": "#c9a84c",
+    "low": "#8a8578",
+}
 
 
-def escape(text):
-    if not text:
-        return ""
-    return text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+def sb_get(table, select="*", filters="", order=None, limit=None):
+    url = f"{SB_REST}/{table}?select={quote(select)}"
+    if filters:
+        url += f"&{filters.replace('+', '%2B')}"
+    if order:
+        url += f"&order={order}"
+    if limit:
+        url += f"&limit={limit}"
+    req = urllib.request.Request(url, headers=SB_HEADERS)
+    with urllib.request.urlopen(req, timeout=15) as resp:
+        return json.loads(resp.read())
 
 
-def render_item_html(row):
-    summary = escape(row.get("ai_summary") or "")
-    message = escape((row.get("message") or "")[:200])
-    priority = row.get("priority") or "medium"
-    player = escape(row.get("player_name") or "Anonymous")
-    created = row.get("created_at", "")[:16].replace("T", " ")
+def generate_summary(items):
+    if not ANTHROPIC_API_KEY or not items:
+        return None
+    feedback_text = "\n".join(
+        f"- [{it['category']}][{it['priority']}] {it.get('ai_summary') or it.get('message', '')[:120]}"
+        for it in items[:50]
+    )
+    payload = json.dumps({
+        "model": "claude-sonnet-4-20250514",
+        "max_tokens": 500,
+        "messages": [{
+            "role": "user",
+            "content": f"""You are an analyst for Uncivilized, a 4X strategy game. Below is the last {HOURS}h of player feedback.
 
-    display_text = summary or message
-    if not display_text:
-        display_text = "(empty)"
+Write a brief executive summary (3-5 bullet points) highlighting:
+1. The most urgent issues players are reporting
+2. The most requested features
+3. Overall player sentiment
+4. Any patterns or recurring themes
 
-    return f"""<tr><td style="padding:8px 12px;border-bottom:1px solid #222220">
-      <div style="display:flex;align-items:center;gap:8px;margin-bottom:4px">
-        {render_priority_badge(priority)}
-        <span style="color:#8a8578;font-size:12px">{player} &middot; {created} UTC</span>
-      </div>
-      <div style="color:#e8e0d0;font-size:14px;line-height:20px">{display_text}</div>
-    </td></tr>"""
+Be specific — cite actual feedback where relevant. Keep it concise and actionable.
 
-
-def render_email(rows, by_category, priority_counts, category_counts, hours):
-    date_str = datetime.now(timezone.utc).strftime("%B %d, %Y")
-    total = len(rows)
-
-    if total == 0:
-        summary_html = f"""<tr><td style="color:#b8b0a0;font-size:15px;line-height:26px;padding:0 0 24px">
-          No new feedback in the last {hours} hours. All quiet on the frontier.
-        </td></tr>"""
-        sections_html = ""
-    else:
-        stat_pills = []
-        for pri in ["critical", "high", "medium", "low"]:
-            count = priority_counts.get(pri, 0)
-            if count > 0:
-                color = PRIORITY_COLORS[pri]
-                stat_pills.append(
-                    f'<span style="display:inline-block;background:{color}22;color:{color};border:1px solid {color}44;'
-                    f'font-size:13px;font-weight:600;padding:4px 12px;border-radius:4px;margin:0 4px 4px 0">'
-                    f'{count} {pri}</span>'
-                )
-
-        summary_html = f"""<tr><td style="padding:0 0 24px">
-          <div style="color:#e8e0d0;font-size:18px;font-weight:600;margin-bottom:8px">{total} feedback items in the last {hours}h</div>
-          <div>{''.join(stat_pills)}</div>
-        </td></tr>"""
-
-        sections = []
-        for cat in CATEGORY_ORDER:
-            items = by_category.get(cat, [])
-            if not items:
-                continue
-            color = CATEGORY_COLORS.get(cat, "#888")
-            label = CATEGORY_LABELS.get(cat, cat)
-            items_html = "".join(render_item_html(r) for r in items)
-            sections.append(f"""<tr><td style="padding:0 0 20px">
-              <div style="color:{color};font-size:16px;font-weight:600;padding:0 0 8px;border-bottom:2px solid {color}44;margin-bottom:0">
-                {label} ({len(items)})
-              </div>
-              <table width="100%" cellpadding="0" cellspacing="0" style="background:#151715;border:1px solid #222220;border-radius:8px;border-top:none">
-                {items_html}
-              </table>
-            </td></tr>""")
-        sections_html = "".join(sections)
-
-    template_path = os.path.join(SCRIPT_DIR, "feedback-digest.html")
-    with open(template_path, "r") as f:
-        template = f.read()
-
-    return template.replace("{{date}}", date_str) \
-                    .replace("{{summary}}", summary_html) \
-                    .replace("{{sections}}", sections_html)
+Feedback:
+{feedback_text}"""
+        }]
+    }).encode()
+    req = urllib.request.Request(
+        "https://api.anthropic.com/v1/messages",
+        data=payload,
+        headers={
+            "Content-Type": "application/json",
+            "x-api-key": ANTHROPIC_API_KEY,
+            "anthropic-version": "2023-06-01",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            data = json.loads(resp.read())
+            return data["content"][0]["text"]
+    except Exception as e:
+        print(f"[WARN] Claude summary failed: {e}")
+        return None
 
 
-# ── Send email ──────────────────────────────────────────────────────
+def build_html(items, summary_text):
+    now = datetime.now(timezone.utc)
+    since = now - timedelta(hours=HOURS)
+
+    by_category = defaultdict(list)
+    by_priority = defaultdict(int)
+    for it in items:
+        cat = it.get("category") or "other"
+        pri = it.get("priority") or "medium"
+        by_category[cat].append(it)
+        by_priority[pri] += 1
+
+    total = len(items)
+    stats_html = f"""
+    <div style="background:#1a1a2e;padding:20px;border-radius:8px;margin-bottom:24px;">
+      <h2 style="color:#c9a84c;margin:0 0 16px 0;font-size:20px;">
+        \U0001f4ca {total} feedback item{"s" if total != 1 else ""} in the last {HOURS}h
+      </h2>
+      <div style="display:flex;gap:16px;flex-wrap:wrap;">
+    """
+    for pri in PRIORITY_ORDER:
+        count = by_priority.get(pri, 0)
+        if count:
+            color = PRIORITY_COLORS[pri]
+            stats_html += f"""
+        <div style="background:{color}22;border:1px solid {color};border-radius:6px;padding:8px 16px;">
+          <span style="color:{color};font-weight:bold;font-size:18px;">{count}</span>
+          <span style="color:#ccc;font-size:13px;margin-left:4px;">{pri}</span>
+        </div>"""
+    stats_html += "</div></div>"
+
+    summary_html = ""
+    if summary_text:
+        formatted = summary_text.replace("\n", "<br>")
+        summary_html = f"""
+    <div style="background:#1a1a2e;padding:20px;border-radius:8px;margin-bottom:24px;border-left:3px solid #5b8dd9;">
+      <h2 style="color:#5b8dd9;margin:0 0 12px 0;font-size:18px;">AI Summary</h2>
+      <div style="color:#ddd;font-size:14px;line-height:1.6;">{formatted}</div>
+    </div>"""
+
+    sections_html = ""
+    for cat_key in ["bug_report", "feature_request", "gameplay_feedback", "question", "other"]:
+        cat_items = by_category.get(cat_key, [])
+        if not cat_items:
+            continue
+        cat_items.sort(key=lambda x: PRIORITY_ORDER.index(x.get("priority", "medium"))
+                       if x.get("priority") in PRIORITY_ORDER else 99)
+        color = CATEGORY_COLORS.get(cat_key, "#555")
+        label = CATEGORY_LABELS.get(cat_key, cat_key)
+        sections_html += f"""
+    <div style="margin-bottom:24px;">
+      <h2 style="color:{color};font-size:18px;margin:0 0 12px 0;padding-bottom:8px;border-bottom:1px solid #333;">
+        {label} ({len(cat_items)})
+      </h2>"""
+        for it in cat_items:
+            pri = it.get("priority", "medium")
+            pri_color = PRIORITY_COLORS.get(pri, "#888")
+            summary = it.get("ai_summary") or (it.get("message") or "")[:120]
+            player = it.get("player_name") or "Anonymous"
+            created = it.get("created_at", "")[:16].replace("T", " ")
+            msg_preview = (it.get("message") or "")[:200]
+            if len(it.get("message") or "") > 200:
+                msg_preview += "…"
+            sections_html += f"""
+      <div style="background:#1a1a2e;padding:12px 16px;border-radius:6px;margin-bottom:8px;border-left:3px solid {pri_color};">
+        <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:4px;">
+          <span style="color:#eee;font-weight:bold;font-size:14px;">{summary}</span>
+          <span style="background:{pri_color}33;color:{pri_color};font-size:11px;padding:2px 8px;border-radius:4px;white-space:nowrap;">{pri}</span>
+        </div>
+        <div style="color:#999;font-size:12px;margin-bottom:4px;">\U0001f464 {player} · {created} UTC</div>
+        <div style="color:#aaa;font-size:13px;font-style:italic;">\"{msg_preview}\"</div>
+      </div>"""
+        sections_html += "</div>"
+
+    return f"""<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"></head>
+<body style="background:#0d0d1a;color:#eee;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;padding:24px;margin:0;">
+  <div style="max-width:640px;margin:0 auto;">
+    <div style="text-align:center;margin-bottom:24px;">
+      <h1 style="color:#c9a84c;font-size:24px;margin:0;">⚔️ Uncivilized — Player Feedback Digest</h1>
+      <p style="color:#888;font-size:13px;margin:8px 0 0 0;">
+        {since.strftime('%b %d %H:%M')} – {now.strftime('%b %d %H:%M')} UTC
+      </p>
+    </div>
+    {stats_html}
+    {summary_html}
+    {sections_html}
+    <div style="text-align:center;color:#666;font-size:12px;margin-top:32px;padding-top:16px;border-top:1px solid #333;">
+      Feedback Digest · Uncivilized · <a href="https://uncivilized.fun" style="color:#5b8dd9;">uncivilized.fun</a>
+    </div>
+  </div>
+</body>
+</html>"""
+
+
 def send_email(subject, html_body):
-    payload = {
+    if not RESEND_API_KEY:
+        print("[ERROR] RESEND_API_KEY not set — cannot send email")
+        sys.exit(1)
+    payload = json.dumps({
         "from": FROM_EMAIL,
         "to": [DIGEST_EMAIL],
         "subject": subject,
         "html": html_body,
-    }
-    return _req("POST", "https://api.resend.com/emails", data=payload, headers={
-        "Authorization": f"Bearer {RESEND_API_KEY}",
-        "Content-Type": "application/json",
-    })
+    }).encode()
+    req = urllib.request.Request(
+        "https://api.resend.com/emails",
+        data=payload,
+        headers={
+            "Authorization": f"Bearer {RESEND_API_KEY}",
+            "Content-Type": "application/json",
+        },
+    )
+    with urllib.request.urlopen(req, timeout=15) as resp:
+        result = json.loads(resp.read())
+        print(f"[OK] Email sent: {result.get('id', 'unknown')}")
 
 
-# ── Main ────────────────────────────────────────────────────────────
 def main():
-    print(f"Fetching feedback from last {HOURS} hours...")
-    rows = fetch_recent_feedback(HOURS)
-    print(f"Found {len(rows)} feedback items")
+    now = datetime.now(timezone.utc)
+    since = now - timedelta(hours=HOURS)
+    since_iso = since.isoformat()
 
-    by_category, priority_counts, category_counts = build_digest(rows)
+    print(f"Fetching feedback since {since_iso} ({HOURS}h window)")
 
-    for cat in CATEGORY_ORDER:
-        items = by_category.get(cat, [])
-        if items:
-            label = CATEGORY_LABELS.get(cat, cat)
-            print(f"\n  {label}: {len(items)}")
-            for r in items:
-                pri = r.get("priority", "?")
-                summary = r.get("ai_summary") or (r.get("message") or "")[:80]
-                print(f"    [{pri}] {summary}")
+    items = sb_get(
+        "feedback",
+        select="id,visitor_id,player_name,message,category,priority,ai_summary,created_at,status",
+        filters=f"created_at=gte.{since_iso}",
+        order="created_at.desc",
+    )
 
-    for pri in ["critical", "high", "medium", "low"]:
-        count = priority_counts.get(pri, 0)
-        if count:
-            print(f"  {pri}: {count}")
+    print(f"Found {len(items)} feedback items")
 
-    date_str = datetime.now(timezone.utc).strftime("%b %d")
-    subject = f"Feedback Digest — {date_str} — {len(rows)} items"
-    html_body = render_email(rows, by_category, priority_counts, category_counts, HOURS)
+    if not items:
+        print("No feedback in this period — skipping digest.")
+        if not DRY_RUN:
+            send_email(
+                f"Uncivilized Feedback Digest — No new feedback",
+                build_html([], None),
+            )
+        return
+
+    by_cat = defaultdict(int)
+    by_pri = defaultdict(int)
+    for it in items:
+        by_cat[it.get("category", "other")] += 1
+        by_pri[it.get("priority", "medium")] += 1
+
+    print(f"Categories: {dict(by_cat)}")
+    print(f"Priorities: {dict(by_pri)}")
+
+    summary = generate_summary(items)
+    if summary:
+        print(f"Generated AI summary ({len(summary)} chars)")
+
+    html = build_html(items, summary)
+
+    critical = by_pri.get("critical", 0)
+    high = by_pri.get("high", 0)
+    subject_parts = [f"Uncivilized Feedback Digest — {len(items)} item{'s' if len(items) != 1 else ''}"]
+    if critical:
+        subject_parts.append(f"\U0001f534 {critical} critical")
+    if high:
+        subject_parts.append(f"\U0001f7e0 {high} high")
+    subject = " · ".join(subject_parts)
 
     if DRY_RUN:
         print(f"\n[DRY RUN] Would send to: {DIGEST_EMAIL}")
         print(f"[DRY RUN] Subject: {subject}")
-        preview_path = os.path.join(SCRIPT_DIR, "feedback-digest-preview.html")
-        with open(preview_path, "w") as f:
-            f.write(html_body)
-        print(f"[DRY RUN] Preview saved to {preview_path}")
+        print(f"[DRY RUN] HTML length: {len(html)} chars")
+        if summary:
+            print(f"\nAI Summary:\n{summary}")
+        for it in items[:10]:
+            print(f"  [{it.get('priority')}] [{it.get('category')}] {it.get('ai_summary', '')[:80]}")
+        if len(items) > 10:
+            print(f"  ... and {len(items) - 10} more")
     else:
-        print(f"\nSending digest to {DIGEST_EMAIL}...")
-        result = send_email(subject, html_body)
-        print(f"Sent: {result}")
+        send_email(subject, html)
+        print(f"Digest sent to {DIGEST_EMAIL}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Adds `scripts/feedback-digest.py` — queries Supabase `feedback` table for the last 24h, groups by category (bug reports, feature requests, gameplay feedback, questions, other) and priority (critical/high/medium/low), generates an AI executive summary via Claude, and emails a styled HTML digest via Resend
- Adds `.github/workflows/feedback-digest.yml` — runs daily at 8am UTC on cron, also supports manual dispatch with configurable `hours`, `dry_run`, and `digest_email` inputs
- Updates CLAUDE.md with new script and workflow documentation

## How it works

1. Queries Supabase PostgREST API for feedback items created in the lookback window
2. Groups items by category and priority
3. Sends up to 50 items to Claude Sonnet for an executive summary (3-5 bullet points: urgent issues, top feature requests, sentiment, patterns)
4. Builds a styled HTML email with priority stats, AI summary, and all items organized by category
5. Sends via Resend to the configured recipient

## Email format

- Priority badge counts at top (critical/high/medium/low)
- AI-generated executive summary section
- Sections per category with items sorted by priority
- Each item shows: AI summary, priority badge, player name, timestamp, message preview

## Secrets required

All already configured for existing workflows:
- `SUPABASE_URL`, `SUPABASE_SERVICE_KEY` — database access
- `RESEND_API_KEY` — email delivery
- `ANTHROPIC_API_KEY` — AI summary generation

## Test plan

- [ ] Trigger workflow manually with `dry_run: true` to verify Supabase query works
- [ ] Trigger with a test email override to verify email delivery and rendering
- [ ] Verify cron fires at 8am UTC the next day

https://claude.ai/code/session_01Bg2PjJcrePGGswbke6Qu1F