### PR TITLE
feat: daily feedback summary email digest

### DIFF
--- a/.github/workflows/feedback-summary.yml
+++ b/.github/workflows/feedback-summary.yml
@@ -1,0 +1,44 @@
+name: Daily Feedback Summary
+
+on:
+  schedule:
+    # Every day at 8am UTC
+    - cron: '0 8 * * *'
+  workflow_dispatch:
+    inputs:
+      hours:
+        description: 'Hours to look back (default: 24)'
+        required: false
+        default: '24'
+      dry_run:
+        description: 'Preview without sending (true/false)'
+        required: false
+        default: 'false'
+      test_email:
+        description: 'Send to this address instead of the default recipient'
+        required: false
+        default: ''
+
+jobs:
+  summarise:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Send feedback summary
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+          RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
+          HOURS: ${{ github.event.inputs.hours || '24' }}
+          DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
+          TEST_EMAIL: ${{ github.event.inputs.test_email || '' }}
+        run: python scripts/feedback-summary.py

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ esbuild resolves these via the `alias` config in `esbuild.config.mjs`.
 ES modules under `src/`, bundled by esbuild into `game.js` (IIFE format, gitignored). Key modules:
 
 | Module | Purpose |
-|--------|---------|
+|--------|--------|
 | `src/main.js` | Entry point, wires modules, exposes window globals |
 | `src/state.js` | Shared mutable state (game, canvas, camera, drag) |
 | `src/constants.js` | Game data: terrain, units, buildings, techs, factions |
@@ -98,7 +98,7 @@ Two near-identical copies: `server.py` (local dev) and `api/index.py` (Vercel pr
 ### Core Endpoints (both server.py and api/index.py)
 
 | Endpoint | Method | Purpose |
-|----------|--------|---------|
+|----------|--------|--------|
 | `/api/chat` | POST | AI diplomacy (requires diplomacy plugin + ANTHROPIC_API_KEY) |
 | `/api/characters` | GET | List available AI leaders |
 | `/api/save` | POST | Save game state (keyed by visitor_id) |
@@ -118,7 +118,7 @@ Two near-identical copies: `server.py` (local dev) and `api/index.py` (Vercel pr
 ### Production-Only Endpoints (api/index.py)
 
 | Endpoint | Method | Purpose |
-|----------|--------|---------|
+|----------|--------|--------|
 | `/api/signup` | POST | Player registration with email verification |
 | `/api/signin` | POST | Player authentication |
 | `/api/verify-token/:token` | GET | Email/token verification |
@@ -132,13 +132,15 @@ Note: `/api/chat` and `/api/characters` are diplomacy endpoints that still live 
 ## Scripts
 
 | Script | Purpose |
-|--------|---------|
+|--------|--------|
 | `scripts/conviction-triage.py` | Auto-triages new GitHub issues with conviction scoring |
 | `scripts/conviction-close.py` | Nightly auto-close of conviction issues resolved by merged PRs |
 | `scripts/newsletter.py` | Sends newsletter emails to active players via Resend API |
 | `scripts/newsletter.html` | Reusable newsletter HTML template (dynamic placeholders) |
 | `scripts/newsletter-launch.html` | Open-source launch announcement template (baked-in content) |
 | `scripts/release-vote.py` | Manages release vote issues: creates changelog, tallies reactions, creates devel→main PR |
+| `scripts/feedback-summary.py` | Daily email digest of player feedback, categorised by type and prioritised |
+| `scripts/feedback-summary.html` | HTML email template for the daily feedback summary |
 | `scripts/newsletter.sql` | SQL migration for feedback `thanked_at` and player `email_opt_out` columns |
 
 **Newsletter system:** Supports two templates (`TEMPLATE=newsletter` or `TEMPLATE=launch`), test-send to a single address (`TEST_EMAIL=...`), dry-run mode, and per-player HMAC-signed unsubscribe links. Only sends to active players (not waitlisted).
@@ -187,6 +189,7 @@ Deployed on Vercel (`uncivilised-game-v2` project). Vercel auto-deploys are disa
 - `.github/workflows/conviction-automerge.yml` — auto-merges conviction PRs (`fix/*` → `devel`) after all CI checks pass and at least one approving review. Triggered by `pull_request_review` and `check_suite` events.
 - `.github/workflows/release-vote.yml` — weekly (Monday 12pm UTC) + manual. Creates a "Release Vote" GitHub issue listing changes on `devel` since `main`. Players vote with reactions (thumbs up/down). At 3 net upvotes, a `devel` → `main` PR is created automatically. Runs `scripts/release-vote.py`.
 - `.github/workflows/newsletter.yml` — manual-only workflow to send emails to active players. Inputs: `template` (newsletter/launch), `message`, `subject`, `dry_run`, `test_email`. Runs `scripts/newsletter.py`.
+- `.github/workflows/feedback-summary.yml` — daily at 8am UTC + manual. Emails a categorised, prioritised digest of player feedback from the last 24 hours. Inputs: `hours`, `dry_run`, `test_email`. Runs `scripts/feedback-summary.py`.
 
 **Important:** `main` is production. Always work on `devel` or feature branches. If you're about to commit to `main` directly or create a PR targeting `main`, confirm with the user first — they likely want to target `devel` instead.
 

--- a/scripts/feedback-summary.html
+++ b/scripts/feedback-summary.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html><html><head><meta charset="utf-8">
+<link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@600;700&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+</head>
+<body style="margin:0;padding:0;background:#0d0f0e;font-family:Inter,-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif">
+<table width="100%" cellpadding="0" cellspacing="0" style="background:#0d0f0e;padding:40px 20px"><tr><td align="center">
+<table width="620" cellpadding="0" cellspacing="0" style="max-width:620px;width:100%">
+
+<!-- HEADER -->
+<tr><td style="padding:0 0 10px">
+  <table width="100%" cellpadding="0" cellspacing="0"><tr>
+    <td style="text-align:left;vertical-align:middle">
+      <svg viewBox="0 0 400 60" width="260" height="39" aria-label="Uncivilised Beta" style="display:block">
+        <defs>
+          <linearGradient id="lg" x1="0" y1="0" x2="1" y2="1">
+            <stop offset="0%" stop-color="#c9a84c"/>
+            <stop offset="100%" stop-color="#8b6914"/>
+          </linearGradient>
+        </defs>
+        <text x="0" y="44" font-family="Cormorant Garamond, Georgia, serif" font-weight="700" font-size="48" fill="url(#lg)">UNCIVILISED</text>
+        <line x1="0" y1="54" x2="360" y2="54" stroke="#c9a84c" stroke-width="0.5" opacity="0.6"/>
+      </svg>
+    </td>
+    <td style="text-align:right;vertical-align:middle;color:#5a5548;font-size:12px">
+      {{generated_at}}
+    </td>
+  </tr></table>
+</td></tr>
+
+<!-- thin gold line -->
+<tr><td style="padding:0 0 24px"><div style="height:1px;background:linear-gradient(to right,#c9a84c50,transparent)"></div></td></tr>
+
+<!-- TITLE -->
+<tr><td style="color:#e8e0d0;font-family:'Cormorant Garamond',Georgia,serif;font-size:26px;line-height:32px;padding:0 0 6px;font-weight:600">Feedback Digest</td></tr>
+<tr><td style="color:#8a8578;font-size:14px;line-height:20px;padding:0 0 20px">{{period_label}} &mdash; {{total}} items received</td></tr>
+
+<!-- PRIORITY OVERVIEW -->
+<tr><td style="padding:0 0 8px">{{stats}}</td></tr>
+
+<!-- CATEGORY SECTIONS -->
+{{sections}}
+
+<!-- FOOTER -->
+<tr><td style="padding:32px 0 0"><div style="height:1px;background:linear-gradient(to right,transparent,#c9a84c15,transparent)"></div></td></tr>
+<tr><td style="padding:16px 0 0">
+  <table width="100%" cellpadding="0" cellspacing="0"><tr>
+    <td style="color:#5a5548;font-size:12px;line-height:18px;text-align:left">
+      Uncivilised &mdash; Daily Feedback Summary<br>
+      <a href="https://uncivilized.fun" style="color:#8a8578;text-decoration:none">uncivilized.fun</a>
+    </td>
+    <td width="80" style="text-align:right;white-space:nowrap;vertical-align:middle">
+      <a href="https://discord.gg/m8BzGbwmvM" style="text-decoration:none;margin-right:4px;display:inline-block;width:28px;height:28px;line-height:28px;text-align:center;background:#1a1a1a;border-radius:6px;border:1px solid #2a2a28" title="Discord">
+        <img src="https://cdn.simpleicons.org/discord/5a5548" alt="Discord" width="14" height="14" style="vertical-align:middle;border:0">
+      </a>
+      <a href="https://github.com/uncivilised-game/uncivilised-game-base" style="text-decoration:none;display:inline-block;width:28px;height:28px;line-height:28px;text-align:center;background:#1a1a1a;border-radius:6px;border:1px solid #2a2a28" title="GitHub">
+        <img src="https://cdn.simpleicons.org/github/5a5548" alt="GitHub" width="14" height="14" style="vertical-align:middle;border:0">
+      </a>
+    </td>
+  </tr></table>
+</td></tr>
+
+</table></td></tr></table></body></html>

--- a/scripts/feedback-summary.py
+++ b/scripts/feedback-summary.py
@@ -1,0 +1,318 @@
+#!/usr/bin/env python3
+"""
+Feedback Summary — daily email digest of player feedback, categorised and prioritised.
+
+Queries Supabase for feedback from the last 24 hours (configurable), groups by
+category and priority, and sends a formatted HTML email via Resend.
+
+Runs on a daily schedule (GitHub Actions) or manually.
+Requires: SUPABASE_URL, SUPABASE_SERVICE_KEY, RESEND_API_KEY
+Optional: SUMMARY_EMAIL, HOURS=24, DRY_RUN=true, TEST_EMAIL=you@example.com
+"""
+
+import os
+import sys
+import json
+import time
+import html
+import urllib.request
+import urllib.error
+from datetime import datetime, timezone, timedelta
+from collections import defaultdict
+
+# ── Config ──────────────────────────────────────────────────────────
+SUPABASE_URL = os.environ["SUPABASE_URL"]
+SUPABASE_KEY = os.environ["SUPABASE_SERVICE_KEY"]
+RESEND_API_KEY = os.environ["RESEND_API_KEY"]
+
+SUMMARY_EMAIL = os.environ.get("SUMMARY_EMAIL", "jamie247@gmail.com")
+HOURS = int(os.environ.get("HOURS", "24"))
+DRY_RUN = os.environ.get("DRY_RUN", "false").lower() == "true"
+TEST_EMAIL = os.environ.get("TEST_EMAIL", "")
+
+FROM_EMAIL = "Uncivilized <hello@uncivilized.fun>"
+REPLY_TO_EMAIL = "hello@uncivilized.fun"
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+
+CATEGORY_ORDER = ["bug_report", "feature_request", "gameplay_feedback", "question", "other"]
+CATEGORY_LABELS = {
+    "bug_report": "Bug Reports",
+    "feature_request": "Feature Requests",
+    "gameplay_feedback": "Gameplay Feedback",
+    "question": "Questions",
+    "other": "Other",
+}
+CATEGORY_ICONS = {
+    "bug_report": "&#x1F41B;",
+    "feature_request": "&#x2728;",
+    "gameplay_feedback": "&#x1F3AE;",
+    "question": "&#x2753;",
+    "other": "&#x1F4AC;",
+}
+CATEGORY_COLORS = {
+    "bug_report": "#d9534f",
+    "feature_request": "#5b8dd9",
+    "gameplay_feedback": "#c9a84c",
+    "question": "#8a8578",
+    "other": "#6a6560",
+}
+PRIORITY_ORDER = ["critical", "high", "medium", "low"]
+PRIORITY_COLORS = {
+    "critical": "#ff4444",
+    "high": "#e8963a",
+    "medium": "#c9a84c",
+    "low": "#8a8578",
+}
+
+
+# ── HTTP helpers (same pattern as other scripts) ────────────────────
+def _req(method, url, data=None, headers=None, retries=2):
+    headers = headers or {}
+    body = json.dumps(data).encode() if data is not None else None
+    if body and "Content-Type" not in headers:
+        headers["Content-Type"] = "application/json"
+    for attempt in range(retries + 1):
+        try:
+            req = urllib.request.Request(url, data=body, headers=headers, method=method)
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                raw = resp.read().decode()
+                return json.loads(raw) if raw else {}
+        except urllib.error.HTTPError as e:
+            err_body = e.read().decode() if e.fp else ""
+            if attempt == retries:
+                print(f"HTTP {e.code} {method} {url}: {err_body}", file=sys.stderr)
+                raise
+            time.sleep(2 ** attempt)
+        except Exception:
+            if attempt == retries:
+                raise
+            time.sleep(2 ** attempt)
+
+
+def sb_get(path, params=""):
+    url = f"{SUPABASE_URL}/rest/v1/{path}?{params}" if params else f"{SUPABASE_URL}/rest/v1/{path}"
+    return _req("GET", url, headers={
+        "apikey": SUPABASE_KEY,
+        "Authorization": f"Bearer {SUPABASE_KEY}",
+    })
+
+
+# ── Fetch feedback ──────────────────────────────────────────────────
+def fetch_recent_feedback():
+    cutoff = (datetime.now(timezone.utc) - timedelta(hours=HOURS)).isoformat()
+    params = (
+        f"created_at=gte.{cutoff}"
+        f"&select=id,message,category,priority,ai_summary,player_name,visitor_id,status,github_issue_number,created_at"
+        f"&order=created_at.desc"
+    )
+    return sb_get("feedback", params)
+
+
+# ── Group and sort ──────────────────────────────────────────────────
+def organise_feedback(rows):
+    by_category = defaultdict(list)
+    for row in rows:
+        cat = row.get("category", "other") or "other"
+        by_category[cat].append(row)
+
+    for cat in by_category:
+        by_category[cat].sort(
+            key=lambda r: PRIORITY_ORDER.index(r.get("priority", "low"))
+            if r.get("priority") in PRIORITY_ORDER else 99
+        )
+
+    return by_category
+
+
+def count_by_priority(rows):
+    counts = defaultdict(int)
+    for row in rows:
+        counts[row.get("priority", "low")] += 1
+    return counts
+
+
+# ── Build HTML email ────────────────────────────────────────────────
+def build_email_html(by_category, total, period_label):
+    template_path = os.path.join(SCRIPT_DIR, "feedback-summary.html")
+    with open(template_path, "r") as f:
+        template = f.read()
+
+    all_priority_counts = count_by_priority(
+        [row for rows in by_category.values() for row in rows]
+    )
+
+    stats_html = ""
+    for pri in PRIORITY_ORDER:
+        count = all_priority_counts.get(pri, 0)
+        if count == 0:
+            continue
+        color = PRIORITY_COLORS[pri]
+        stats_html += (
+            f'<span style="display:inline-block;background:{color}20;color:{color};'
+            f'font-size:13px;font-weight:600;padding:4px 12px;border-radius:4px;'
+            f'margin-right:8px;margin-bottom:4px">'
+            f'{pri.upper()}: {count}</span>'
+        )
+
+    sections_html = ""
+    for cat in CATEGORY_ORDER:
+        items = by_category.get(cat, [])
+        if not items:
+            continue
+
+        icon = CATEGORY_ICONS.get(cat, "")
+        label = CATEGORY_LABELS.get(cat, cat)
+        color = CATEGORY_COLORS.get(cat, "#c9a84c")
+
+        items_html = ""
+        for item in items:
+            pri = item.get("priority", "low")
+            pri_color = PRIORITY_COLORS.get(pri, "#8a8578")
+            summary = html.escape(item.get("ai_summary") or item.get("message", "")[:120])
+            player = html.escape(item.get("player_name") or "anonymous")
+            created = item.get("created_at", "")[:16].replace("T", " ")
+
+            issue_badge = ""
+            if item.get("github_issue_number"):
+                issue_badge = (
+                    f' <a href="https://github.com/uncivilised-game/uncivilised-game-base/issues/{item["github_issue_number"]}"'
+                    f' style="color:#8a8578;font-size:11px;text-decoration:none">'
+                    f'#{item["github_issue_number"]}</a>'
+                )
+
+            items_html += (
+                f'<tr><td style="padding:8px 0;border-bottom:1px solid #1a1a18">'
+                f'<div style="display:flex;align-items:center;gap:8px;margin-bottom:4px">'
+                f'<span style="display:inline-block;background:{pri_color}20;color:{pri_color};'
+                f'font-size:11px;font-weight:600;padding:2px 8px;border-radius:3px;text-transform:uppercase">{pri}</span>'
+                f'<span style="color:#5a5548;font-size:12px">{player} &middot; {created}</span>'
+                f'{issue_badge}'
+                f'</div>'
+                f'<div style="color:#b8b0a0;font-size:14px;line-height:20px">{summary}</div>'
+                f'</td></tr>'
+            )
+
+        sections_html += (
+            f'<tr><td style="padding:20px 0 8px">'
+            f'<div style="display:flex;align-items:center;gap:8px;margin-bottom:12px">'
+            f'<span style="font-size:20px">{icon}</span>'
+            f'<span style="color:{color};font-family:\'Cormorant Garamond\',Georgia,serif;'
+            f'font-size:20px;font-weight:600">{label}</span>'
+            f'<span style="color:#5a5548;font-size:14px">({len(items)})</span>'
+            f'</div>'
+            f'<table width="100%" cellpadding="0" cellspacing="0">{items_html}</table>'
+            f'</td></tr>'
+        )
+
+    if not sections_html:
+        sections_html = (
+            '<tr><td style="padding:40px 0;text-align:center;color:#5a5548;font-size:15px">'
+            'No feedback received in this period.'
+            '</td></tr>'
+        )
+
+    email_html = template.replace("{{period_label}}", html.escape(period_label))
+    email_html = email_html.replace("{{total}}", str(total))
+    email_html = email_html.replace("{{stats}}", stats_html)
+    email_html = email_html.replace("{{sections}}", sections_html)
+    email_html = email_html.replace("{{generated_at}}", datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC"))
+
+    return email_html
+
+
+def build_email_text(by_category, total, period_label):
+    lines = [
+        f"Uncivilised — Feedback Summary",
+        f"{period_label} | {total} items",
+        "",
+    ]
+
+    for cat in CATEGORY_ORDER:
+        items = by_category.get(cat, [])
+        if not items:
+            continue
+        label = CATEGORY_LABELS.get(cat, cat)
+        lines.append(f"== {label} ({len(items)}) ==")
+        for item in items:
+            pri = item.get("priority", "low").upper()
+            summary = item.get("ai_summary") or item.get("message", "")[:120]
+            player = item.get("player_name") or "anonymous"
+            lines.append(f"  [{pri}] {summary} — {player}")
+        lines.append("")
+
+    if total == 0:
+        lines.append("No feedback received in this period.")
+
+    return "\n".join(lines)
+
+
+# ── Send email ──────────────────────────────────────────────────────
+def send_summary(to_email, subject, html_body, text_body):
+    body = json.dumps({
+        "from": FROM_EMAIL,
+        "to": [to_email],
+        "reply_to": REPLY_TO_EMAIL,
+        "subject": subject,
+        "html": html_body,
+        "text": text_body,
+    }).encode()
+    req = urllib.request.Request(
+        "https://api.resend.com/emails",
+        data=body,
+        headers={
+            "Authorization": f"Bearer {RESEND_API_KEY}",
+            "Content-Type": "application/json",
+            "User-Agent": "uncivilized-feedback-summary/1.0",
+        },
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=10) as resp:
+        if resp.status < 300:
+            print(f"  [EMAIL] Sent summary to {to_email}")
+            return True
+    return False
+
+
+# ── Main ────────────────────────────────────────────────────────────
+def main():
+    print(f"=== Feedback Summary ({HOURS}h window) ===")
+    print(f"  Dry run: {DRY_RUN}")
+
+    rows = fetch_recent_feedback()
+    total = len(rows)
+    print(f"  Found {total} feedback items in the last {HOURS} hours")
+
+    by_category = organise_feedback(rows)
+    for cat in CATEGORY_ORDER:
+        items = by_category.get(cat, [])
+        if items:
+            pri_counts = count_by_priority(items)
+            pri_str = ", ".join(f"{p}={c}" for p, c in sorted(pri_counts.items()))
+            print(f"    {CATEGORY_LABELS.get(cat, cat)}: {len(items)} ({pri_str})")
+
+    period_label = f"Last {HOURS} hours" if HOURS != 24 else "Last 24 hours"
+    today = datetime.now(timezone.utc).strftime("%d %b %Y")
+    subject = f"Feedback Digest — {today} ({total} items)"
+
+    html_body = build_email_html(by_category, total, period_label)
+    text_body = build_email_text(by_category, total, period_label)
+
+    to = TEST_EMAIL or SUMMARY_EMAIL
+
+    if DRY_RUN:
+        print(f"\n  [DRY RUN] Would send to: {to}")
+        print(f"  Subject: {subject}")
+        print(f"\n{text_body}")
+        return
+
+    try:
+        send_summary(to, subject, html_body, text_body)
+    except Exception as e:
+        print(f"  [ERROR] Failed to send: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    print("  Done.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Adds `scripts/feedback-summary.py` that queries Supabase for player feedback from the last 24 hours, groups by category (bugs, features, gameplay, questions) and sorts by priority (critical → low), then sends a formatted HTML email via Resend
- Adds `scripts/feedback-summary.html` email template matching the existing newsletter dark theme styling
- Adds `.github/workflows/feedback-summary.yml` running daily at 8am UTC with manual dispatch support (`hours`, `dry_run`, `test_email` inputs)
- Updates CLAUDE.md with the new script and workflow documentation

## Test plan
- [ ] Trigger the workflow manually with `dry_run=true` to verify it queries Supabase correctly
- [ ] Send a test email via `test_email` input to verify formatting
- [ ] Verify the 8am UTC cron fires correctly on the next day

https://claude.ai/code/session_014W4qCqLfdSjUy9bykRE8gU

---
_Generated by [Claude Code](https://claude.ai/code/session_014W4qCqLfdSjUy9bykRE8gU)_